### PR TITLE
Custom generator for pPb 8 TeV EPOSLHC MC generation with strangeness injection

### DIFF
--- a/MC/CustomGenerators/PWGLF/EPOS_StrInj_pPb8.C
+++ b/MC/CustomGenerators/PWGLF/EPOS_StrInj_pPb8.C
@@ -1,0 +1,20 @@
+AliGenerator *GeneratorCustom(){
+
+  int ninjxi = 3;
+  int ninjom = 3;
+  
+  Int_t sign = uidConfig % 2 == 0 ? 1 : -1;
+  
+  AliGenCocktail *ctl  = GeneratorCocktail("EPOS_StrInj_pPb8");
+  AliGenerator   *epos  = GeneratorEPOSLHC();
+  
+  AliGenerator   *ixi = GeneratorInjector(ninjxi, sign * 3312, 2., 20., -0.7, 0.7);
+  AliGenerator   *iom = GeneratorInjector(ninjom, (-1) * sign * 3334, 0., 10., -0.7, 0.7);
+  
+  ctl->AddGenerator(epos,  "Epos", 1.);
+  ctl->AddGenerator(ixi, "Injector (Xi)", 1.);
+  ctl->AddGenerator(iom, "Injector (Omega)", 1.);
+
+  return ctl;
+
+}


### PR DESCRIPTION
Code to define a Custom Generator which implements a Cocktail with:
* EPOSLHC underlying event
* 3 Xi (or anti-Xi) pt-flat injected per event at high pt (2-20 GeV/c)
* 3 anti-Omega (Omega) pt-flat injected per event for all pt (0-10 GeV/c)
The generator is useful to complement with dedicated production the statistics of cascades contained in general purpose production. 
