### PR TITLE
new settings for muon only MC

### DIFF
--- a/AOD/AODtrainsim.C
+++ b/AOD/AODtrainsim.C
@@ -22,6 +22,7 @@ Bool_t      useCORRFW           = kFALSE;  // do not change
 Bool_t      useAODTAGS          = kFALSE;  // use AOD tags
 Bool_t      useSysInfo          = kFALSE;  // use sys info
 Bool_t      isMuonCaloPass      = kFALSE;  // setting this to kTRUE will disable some not needed analysis tasks for a muon_calo pass
+Bool_t      isMuonOnly          = kFALSE;  // setting this to kTRUE will disable same tasks as isMuonCaloPass and some more
 
 // ### Analysis modules to be included. Some may not be yet fully implemented.
 //==============================================================================
@@ -76,18 +77,30 @@ Int_t run_number = 0;
 void UpdateFlags()
 {
   // Update flags according to type of pass
-  if ( isMuonCaloPass )
+  if ( isMuonCaloPass || isMuonOnly )
   {
     // disable the analysis we know for sure can not work or are meaningless
     // for a muon_calo pass
     doCDBconnect       = kFALSE;
-    iPWGHFvertexing    = 0; 
-    iPWGHFd2h          = 0; 
-    iPWGPP             = 0; 
-    iPWGLFForward      = 0; 
-    iPWGGAgammaconv    = 0; 
-    doPIDResponse      = 0; 
-    doPIDqa            = 0; 
+    useTender          = kFALSE;
+    useV0tender        = kFALSE;
+    iJETAN             = 0;
+    iJETANdelta        = 0;
+    iPWGHFvertexing    = 0;
+    iPWGDQJPSIfilter   = 0;
+    iPWGHFd2h          = 0;
+    iPWGPP             = 0;
+    iPWGLFForward      = 0;
+    iPWGGAgammaconv    = 0;
+    doPIDResponse      = kFALSE;
+    doPIDqa            = kFALSE;
+  }
+  
+  if ( isMuonOnly )
+  {
+    // disable more unnecessary tasks for muon only MC
+    usePhysicsSelection = kFALSE;
+    useCentrality       = kFALSE;
   }
 }
 
@@ -328,7 +341,7 @@ void AddAnalysisTasks(const char *cdb_location)
          mgr->RegisterExtraFile("AliAOD.Muons.root");
       }
 
-      Bool_t muonWithSPDTracklets = (iCollision==kPbPb) ? kFALSE : kTRUE; // add SPD information to muon AOD only for pp
+      Bool_t muonWithSPDTracklets = (iCollision==kPbPb || isMuonOnly) ? kFALSE : kTRUE; // add SPD information to muon AOD only for pp
 
       AliAnalysisTaskESDfilter *taskesdfilter = 
                  AddTaskESDFilter(useKFILTER, 
@@ -343,8 +356,13 @@ void AddAnalysisTasks(const char *cdb_location)
                                   3,                     // muonMCMode
                                   kFALSE,                // useV0Filter 
                                   muonWithSPDTracklets,
-                                  isMuonCaloPass);
-         AliEMCALGeometry::GetInstance("","");
+                                  (isMuonCaloPass || isMuonOnly));
+     if (isMuonOnly) {
+       taskesdfilter->DisableCaloClusters();
+       taskesdfilter->DisableCells();
+       taskesdfilter->DisableCaloTrigger("PHOS");
+       taskesdfilter->DisableCaloTrigger("EMCAL");
+     } else AliEMCALGeometry::GetInstance("","");
    }   
 
 // ********** PWG3 wagons ******************************************************           
@@ -547,11 +565,12 @@ void ProcessEnvironment()
   // Setting this to kTRUE will disable some not needed analysis tasks for a muon_calo pass
   //
   isMuonCaloPass = kFALSE;
+  isMuonOnly = kFALSE;
   if (gSystem->Getenv("CONFIG_AOD"))
   {
     TString configstr = gSystem->Getenv("CONFIG_AOD");
-    if (configstr.Contains("Muon"))
-      isMuonCaloPass = kTRUE;
+    if (configstr.Contains("MuonOnly")) isMuonOnly = kTRUE;
+    else if (configstr.Contains("Muon")) isMuonCaloPass = kTRUE;
   }
 
   //

--- a/MC/Config.C
+++ b/MC/Config.C
@@ -189,7 +189,7 @@ ProcessEnvironment()
   }
 
   // trigger configuration
-  triggerConfig = kGeneratorDefault;
+  triggerConfig = kTriggerDefault;
   if (gSystem->Getenv("CONFIG_TRIGGER")) {
     Bool_t valid = kFALSE;
     for (Int_t itrg = 0; itrg < kNTriggers; itrg++)

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -69,6 +69,7 @@ enum ETrigger_t {
   kTriggerDefault,
   kTriggerPP,
   kTriggerPbPb,
+  kTriggerMuon,
   kTriggerCustom,
   kNTriggers
 };
@@ -77,6 +78,7 @@ const Char_t *TriggerName[kNTriggers] = {
   "ocdb",
   "p-p",
   "Pb-Pb",
+  "MUON",
   "Custom.cfg"
 };
 

--- a/MC/ReconstructionConfig.C
+++ b/MC/ReconstructionConfig.C
@@ -11,7 +11,8 @@
 enum EReconstruction_t {
   kReconstructionDefault,
   kReconstructionMuon,
-  kReconstructionITSpureSA,  
+  kReconstructionMuonOnly,
+  kReconstructionITSpureSA,
   kReconstructionNoSDD,  
   kReconstructionRun1TrackingPID,
   kReconstructionCustom,
@@ -21,6 +22,7 @@ enum EReconstruction_t {
 const Char_t *ReconstructionName[kNReconstructions] = {
   "Default",
   "Muon",
+  "MuonOnly",
   "ITSpureSA",
   "NoSDD",
   "Run1TrackingPID",
@@ -70,6 +72,16 @@ ReconstructionConfig(AliReconstruction &rec, EReconstruction_t tag)
     rec.SetRunReconstruction("MUON ITS VZERO T0 AD");
     return;
 
+    // Muon only
+  case kReconstructionMuonOnly:
+    ReconstructionDefault(rec);
+    rec.SetRunReconstruction("MUON ITS");
+    rec.SetRunQA("MUON:ALL");
+    rec.SetWriteESDfriend(kFALSE);
+    rec.SetRunPlaneEff(kFALSE);
+    rec.SetRecoParam("ITS",OverrideITSRecoParam_VertexerSmearMC());
+    return;
+    
     // ITSpureSA
   case kReconstructionITSpureSA:
     ReconstructionDefault(rec);
@@ -266,6 +278,21 @@ OverrideITSRecoParam_NoSDD_pPb2016()
   itsRecoParam->SetLayerToSkip(2);
   itsRecoParam->SetLayerToSkip(3);
 
+  //
+  return itsRecoParam;
+}
+
+/*****************************************************************/
+
+AliITSRecoParam *
+OverrideITSRecoParam_VertexerSmearMC()
+{
+  AliITSRecoParam *itsRecoParam = AliITSRecoParam::GetLowFluxParam();
+  
+  // use MC vertex with smearing
+  itsRecoParam->SetVertexerSmearMC();
+  itsRecoParam->ReconstructOnlySPD();
+  
   //
   return itsRecoParam;
 }

--- a/MC/SimulationConfig.C
+++ b/MC/SimulationConfig.C
@@ -11,6 +11,7 @@
 enum ESimulation_t {
   kSimulationDefault,
   kSimulationMuon,
+  kSimulationMuonOnly,
   kSimulationEmbedBkg,
   kSimulationEmbedSig,
   kSimulationGeneratorOnly,
@@ -21,6 +22,7 @@ enum ESimulation_t {
 const Char_t *SimulationName[kNSimulations] = {
   "Default",
   "Muon",
+  "MuonOnly",
   "EmbedBkg",
   "EmbedSig",
   "GeneratorOnly",
@@ -50,7 +52,17 @@ SimulationConfig(AliSimulation &sim, ESimulation_t tag)
     sim.SetRunHLT("");
     return;
     
-    // EmbedBkg
+    // Muon only
+  case kSimulationMuonOnly:
+    SimulationDefault(sim);
+    sim.SetMakeSDigits("MUON");
+    sim.SetMakeDigits("MUON");
+    sim.SetMakeDigitsFromHits("");
+    sim.SetRunHLT("");
+    sim.SetRunQA("MUON:ALL");
+    return;
+    
+  // EmbedBkg
   case kSimulationEmbedBkg:
     SimulationDefault(sim);
     sim.SetMakeSDigits("ALL");

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -447,43 +447,60 @@ fi
 
 ### automatic settings from CONFIG_MODE
 
-if [[ $CONFIG_MODE == *"Muon"* ]]; then
+if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
+
     if [[ $CONFIG_DETECTOR == "" ]]; then
         CONFIG_DETECTOR="Muon"
         export CONFIG_DETECTOR
     fi
+
     if [[ $CONFIG_SIMULATION == "" ]]; then
-        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
-            CONFIG_SIMULATION="MuonOnly"
-        else
-            CONFIG_SIMULATION="Muon"
-        fi
+        CONFIG_SIMULATION="MuonOnly"
         export CONFIG_SIMULATION
-   fi
+    fi
+
     if [[ $CONFIG_RECONSTRUCTION == "" ]]; then
-        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
-            CONFIG_RECONSTRUCTION="MuonOnly"
-        else
-            CONFIG_RECONSTRUCTION="Muon"
-        fi
+        CONFIG_RECONSTRUCTION="MuonOnly"
         export CONFIG_RECONSTRUCTION
     fi
+
     if [[ $CONFIG_QA == "" ]]; then
-        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
-            CONFIG_QA="MuonOnly"
-        else
-            CONFIG_QA="Muon"
-        fi
+        CONFIG_QA="MuonOnly"
         export CONFIG_QA
     fi
+
     if [[ $CONFIG_AOD == "" ]]; then
-        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
-            CONFIG_AOD="MuonOnly"
-        else
-            CONFIG_AOD="Muon"
-        fi
+        CONFIG_AOD="MuonOnly"
         export CONFIG_AOD
     fi
+
+elif [[ $CONFIG_MODE == *"Muon"* ]]; then
+
+    if [[ $CONFIG_DETECTOR == "" ]]; then
+        CONFIG_DETECTOR="Muon"
+        export CONFIG_DETECTOR
+    fi
+
+    if [[ $CONFIG_SIMULATION == "" ]]; then
+        CONFIG_SIMULATION="Muon"
+        export CONFIG_SIMULATION
+    fi
+
+    if [[ $CONFIG_RECONSTRUCTION == "" ]]; then
+        CONFIG_RECONSTRUCTION="Muon"
+        export CONFIG_RECONSTRUCTION
+    fi
+
+    if [[ $CONFIG_QA == "" ]]; then
+        CONFIG_QA="Muon"
+        export CONFIG_QA
+    fi
+
+    if [[ $CONFIG_AOD == "" ]]; then
+        CONFIG_AOD="Muon"
+        export CONFIG_AOD
+    fi
+
 fi
 
 ### automatic settings from GRP info

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -449,19 +449,40 @@ fi
 
 if [[ $CONFIG_MODE == *"Muon"* ]]; then
     if [[ $CONFIG_DETECTOR == "" ]]; then
-	export CONFIG_DETECTOR="Muon"
+        CONFIG_DETECTOR="Muon"
+        export CONFIG_DETECTOR
     fi
     if [[ $CONFIG_SIMULATION == "" ]]; then
-	export CONFIG_SIMULATION="Muon"
-    fi
+        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
+            CONFIG_SIMULATION="MuonOnly"
+        else
+            CONFIG_SIMULATION="Muon"
+        fi
+        export CONFIG_SIMULATION
+   fi
     if [[ $CONFIG_RECONSTRUCTION == "" ]]; then
-	export CONFIG_RECONSTRUCTION="Muon"
+        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
+            CONFIG_RECONSTRUCTION="MuonOnly"
+        else
+            CONFIG_RECONSTRUCTION="Muon"
+        fi
+        export CONFIG_RECONSTRUCTION
     fi
     if [[ $CONFIG_QA == "" ]]; then
-	export CONFIG_QA="Muon"
+        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
+            CONFIG_QA="MuonOnly"
+        else
+            CONFIG_QA="Muon"
+        fi
+        export CONFIG_QA
     fi
     if [[ $CONFIG_AOD == "" ]]; then
-	export CONFIG_AOD="Muon"
+        if [[ $CONFIG_MODE == *"MuonOnly"* ]]; then
+            CONFIG_AOD="MuonOnly"
+        else
+            CONFIG_AOD="Muon"
+        fi
+        export CONFIG_AOD
     fi
 fi
 


### PR DESCRIPTION
Hi,

I added a new settings to run muon-only MC, like the ones we use for tracking systematics studies and for J/Psi, Upsilon, etc... AccEff correction calculations. This settings is different from the "muon" settings that correspond to the muon_calo passes and can be used for e.g. tracklet multiplicity studies or by UPC for STARLIGHT MC.

I tested successfully this new settings locally with single muon MC.

Also I tried to be careful not to change any existing behaviour with those modifications, but a double check is more than welcome! :-)

Cheers,
Philippe