### PR TITLE
add pT selection in single simulation for PHOS

### DIFF
--- a/MC/CustomGenerators/PWGGA/SingleParticleGun001.C
+++ b/MC/CustomGenerators/PWGGA/SingleParticleGun001.C
@@ -2,8 +2,8 @@ AliGenerator *GeneratorCustom(TString opt = "")
 {
   AliGenCocktail *ctl  = GeneratorCocktail("SingleParticleGun001");
 
-  const Double_t ptMin=0.5;
-  const Double_t ptMax=100.;
+  Double_t ptMin=0.;
+  Double_t ptMax=100.;
 
   const Double_t yMin=-0.15;
   const Double_t yMax=0.15;
@@ -16,6 +16,12 @@ AliGenerator *GeneratorCustom(TString opt = "")
   Int_t PDGList[nPDG]      = {22, 111, 221};
   TString stringPDG        = "";
   Int_t iPDG               = -1;
+
+  const Int_t nPt = 3;
+  const TString optPtList[nPt]  = {"low","mid","high"};
+  const Double_t PtMinList[nPt] = {   0.,   5.,   40.};//in GeV/c
+  const Double_t PtMaxList[nPt] = {  15.,  50.,  100.};//in GeV/c
+
   for (Int_t iopt = 0; iopt < nPDG; iopt++){
     if (opt.Contains(optPDGList[iopt])){
       iPDG      = PDGList[iopt];
@@ -27,6 +33,15 @@ AliGenerator *GeneratorCustom(TString opt = "")
     printf("ERROR: no valid particle selected\n");
     return NULL;
   }
+
+  for (Int_t iopt = 0; iopt < nPt; iopt++){
+    if (opt.Contains(optPtList[iopt])){
+      ptMin = PtMinList[iopt];
+      ptMax = PtMaxList[iopt];
+    }
+  }
+
+  printf("INFO: %s will be injected in %2.1f < pT < %2.1f (GeV/c)\n",stringPDG.Data(),ptMin,ptMax);
 
   AliGenerator   *particle = GeneratorInjector(1, iPDG, ptMin, ptMax, yMin, yMax, phiMin, phiMax);
   ctl->AddGenerator(particle, Form("Injector (%s)",stringPDG.Data()), 1.);


### PR DESCRIPTION
pT selections low/mid/high are added in order to generate particle in different pT region.
This will reduce CPU time from EM showers point of view in simulation.