### PR TITLE
Increase the TRD validation limit by 10 chambers

### DIFF
--- a/DataProc/CPass0/makeOCDB.C
+++ b/DataProc/CPass0/makeOCDB.C
@@ -202,8 +202,8 @@ void makeOCDB(Int_t runNumber, TString  targetOCDBstorage="", TString sourceOCDB
     procesTRD->SetMinStatsVdriftT0PH(600*10);
     procesTRD->SetMinStatsVdriftLinear(50);
     procesTRD->SetMinStatsGain(600);
-    procesTRD->SetLimitValidateNoData(100);
-    procesTRD->SetLimitValidateBadCalib(90);
+    procesTRD->SetLimitValidateNoData(110);
+    procesTRD->SetLimitValidateBadCalib(110);
     procesTRD->SetMinTimeOffsetValidate(-2.1);
     procesTRD->SetAlternativeDriftVelocityFit(kTRUE);
     if((!isLHC10) && (!isLHC11) && (!isLHC12) && (!isLHC13)) {

--- a/DataProc/CPass1/makeOCDB.C
+++ b/DataProc/CPass1/makeOCDB.C
@@ -208,8 +208,8 @@ void makeOCDB(Int_t runNumber, TString  targetOCDBstorage="", TString sourceOCDB
     procesTRD->SetMinStatsVdriftT0PH(600*10);
     procesTRD->SetMinStatsVdriftLinear(50);
     procesTRD->SetMinStatsGain(600);
-    procesTRD->SetLimitValidateNoData(100);
-    procesTRD->SetLimitValidateBadCalib(90);
+    procesTRD->SetLimitValidateNoData(110);
+    procesTRD->SetLimitValidateBadCalib(110);
     procesTRD->SetMinTimeOffsetValidate(-2.1);
     procesTRD->SetAlternativeDriftVelocityFit(kTRUE);
     if((!isLHC10) && (!isLHC11) && (!isLHC12) && (!isLHC13)) {


### PR DESCRIPTION
Dear all,
since we are very close to the limit of 100 bad chambers and that the QA did not point to any overmasking of the TRD chambers, I propose to increase slightly the validation limit for the TRD cpass0/cpass1.
Best regards,
Raphaelle