### PR TITLE
-- AMPT::v1.26t7-v2.26t7-2 --

### DIFF
--- a/MC/EXTRA/gen_ampt.sh
+++ b/MC/EXTRA/gen_ampt.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "You must specify at least where to write output to as first parameter."
+    exit -1
+fi
+
+echo "running in `pwd`, writing HepMC to $1"
+
+# prepare environment
+source /cvmfs/alice.cern.ch/etc/login.sh
+eval $(alienv printenv AMPT::v1.26t7-v2.26t7-1)
+
+# run generator
+
+# generate random seed
+nrandom=`date '+%d%H%M%S'`
+echo $nrandom > nseed_runtime
+
+if [ -d ana/ ];
+then
+    rm -rf ana/
+fi
+mkdir ana
+cp ${ALICE_PHYSICS}/PWG/MCLEGO/AMPT/input.ampt .
+cp input.ampt ana/
+
+mkfifo ana/ampt.dat
+
+ampt < nseed_runtime &
+parser ana/ampt.dat $1
+
+rm -rf ana/

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -31,7 +31,7 @@ enum EGenerator_t {
   // Starlight
   kGeneratorStarlight,
   // AMPT
-  kGeneratorAMPT,
+  kGeneratorAMPT, kGeneratorAMPT_v226t7,
   //
   kGeneratorCustom,
   //
@@ -66,7 +66,7 @@ const Char_t *GeneratorName[kNGenerators] = {
   // Starlight
   "Starlight",
   // AMPT
-  "AMPT",
+  "AMPT", "AMPT_v226t7",
   //
   "Custom",
   //
@@ -172,6 +172,7 @@ AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t l
 AliGenerator *Generator_Nuclex(UInt_t injbit, Bool_t antiparticle, Int_t ninj, Float_t max_pt = 10.f, Float_t max_y = 1.);
 AliGenerator *GeneratorStarlight();
 AliGenerator *GeneratorAMPT();
+AliGenerator *GeneratorAMPT_v226t7();
 
 /*****************************************************************/
 
@@ -266,6 +267,10 @@ GeneratorConfig(Int_t tag)
     // AMPT
   case kGeneratorAMPT:
     gen = GeneratorAMPT();
+    break;
+
+ case kGeneratorAMPT_v226t7:
+    gen = GeneratorAMPT_v226t7();
     break;
 
     // Custom
@@ -1173,6 +1178,32 @@ GeneratorAMPT() {
   return genHi;
 
   
+}
+
+
+/*** AMPT_v226t7 ****************************************************/
+
+AliGenerator *
+GeneratorAMPT_v226t7()
+{
+
+  // run AMPT_v226t7
+  TString fifoname = "crmceventfifo";
+  gROOT->ProcessLine(Form(".! rm -rf %s", fifoname.Data()));
+  gROOT->ProcessLine(Form(".! mkfifo %s", fifoname.Data()));
+  gROOT->ProcessLine(Form(".! sh $ALIDPG_ROOT/MC/EXTRA/gen_ampt.sh %s %d %d %f %d %f &> gen_ampt.log &",
+			  fifoname.Data(), neventsConfig,
+			  projectileId, projectileEnergy,
+			  targetId, targetEnergy));
+  //
+  // connect HepMC reader
+  AliGenReaderHepMC *reader = new AliGenReaderHepMC();
+  reader->SetFileName("ampteventfifo");
+  AliGenExtFile *gener = new AliGenExtFile(-1);
+  gener->SetName(Form("AMPT_%s", systemConfig.Data()));
+  gener->SetReader(reader);
+  
+  return gener;
 }
 
 /*** COCKTAIL ****************************************************/

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -1188,14 +1188,11 @@ GeneratorAMPT_v226t7()
 {
 
   // run AMPT_v226t7
-  TString fifoname = "crmceventfifo";
+  TString fifoname = "ampteventfifo";
   gROOT->ProcessLine(Form(".! rm -rf %s", fifoname.Data()));
   gROOT->ProcessLine(Form(".! mkfifo %s", fifoname.Data()));
-  gROOT->ProcessLine(Form(".! sh $ALIDPG_ROOT/MC/EXTRA/gen_ampt.sh %s %d %d %f %d %f &> gen_ampt.log &",
-			  fifoname.Data(), neventsConfig,
-			  projectileId, projectileEnergy,
-			  targetId, targetEnergy));
-  //
+  gROOT->ProcessLine(Form(".! sh $ALIDPG_ROOT/MC/EXTRA/gen_ampt.sh %s &> gen_ampt.log &",
+			  fifoname.Data()));
   // connect HepMC reader
   AliGenReaderHepMC *reader = new AliGenReaderHepMC();
   reader->SetFileName("ampteventfifo");


### PR DESCRIPTION
This pull request makes the stand-alone implementation of AMPT available in the AliDPG package

-  AMPT_v2267t is the latest version of AMPT, tuned to LHC run 2 energies (5.02 TeV CM energies)
-  the compiled binary ampt is available in VO_ALICE@AMPT::v1.26t7-v2.26t7-2. this package also contains a parser that parses the native ampt output to HepMC format (the executable is simple called 'parser')  for further processing in AliROOT
- This pull request calls AMPT by resolving the relevant packages via CVMFS and running AMPT as an independent process using the AliGenExtExec interface

Caveats
- This implementation is 'minimal': it serves the goal of showing that components for running are in place as @miweberSMI and I discussed today
- the configuration of the generator is hard-coded in the input.ampt file at $ALICE_PHYSICS/PWG/MCLEGO/AMPT/input.ampt  
- in a future commit, relevant parameters to tune AMPT should be passed as arguments to gen_ampt.sh , which will then in turn generate an input.ampt configuration file on-the-fly. suggested parameters are system size qualifiers, collision energy, impact parameter range, number of timestamps - more parameters can be added if needed

Issues
- the name of the generator is now ' AMPT_v226t7', to allow it to exist next to the AMPT generator that's already available in AliDPG (via the TAmpt interface). This name can of course be changed; if desired, please comment to this PR so that I can amend the PR
- I've tested the implementation on a minimal example, running '$ALIDPG_ROOT/bin/aliroot_dpgsim.sh  --run 225307 --mode ocdb,full --uid 1 --generator AMPT_v226t7 --nevents 10'
- at the very end of running aliroot_dpgsim.sh aliroot segfaults in a double free in the QA train phase, i don't think this is related to the APMT implementation (as all AMPT related processes have ended by this time) , but i cannot easily verify this since my local setup might not be 100% ok