### PR TITLE
ALIROOT-7077: ADD setup for the TPC ion tail and crosstalk simulation

### DIFF
--- a/MC/SimulationConfig.C
+++ b/MC/SimulationConfig.C
@@ -17,6 +17,7 @@ enum ESimulation_t {
   kSimulationGeneratorOnly,
   kSimulationNoDigitization,
   kSimulationCustom,
+  kSimulationDefaultIonTail,
   kNSimulations
 };
 
@@ -28,13 +29,14 @@ const Char_t *SimulationName[kNSimulations] = {
   "EmbedSig",
   "GeneratorOnly",
   "NoDigitization",
-  "Custom"
+  "Custom",
+  "SimulationDefaultIonTail"
 };
 
 
 /*****************************************************************/
 
-SimulationConfig(AliSimulation &sim, ESimulation_t tag)
+void SimulationConfig(AliSimulation &sim, ESimulation_t tag)
 {
   
   printf(">>>>> SimulationConfig: %s \n", SimulationName[tag]);
@@ -123,11 +125,16 @@ SimulationConfig(AliSimulation &sim, ESimulation_t tag)
     SimulationCustom(sim);
     return;
 
+   // Default simulation enabling IonTail/Crosstalk for TPC
+  case kSimulationDefaultIonTail:
+     SimulationDefault(sim);
+     sim.SetMakeSDigits("TPC");
+     return;
   }
-  
+
 }
 
-SimulationDefault(AliSimulation &sim)
+void SimulationDefault(AliSimulation &sim)
 {
 
   Int_t year = atoi(gSystem->Getenv("CONFIG_YEAR"));
@@ -187,7 +194,7 @@ SimulationDefault(AliSimulation &sim)
 
 /*** PHOS ****************************************************/
 
-SimulationConfigPHOS(AliSimulation &sim)
+void SimulationConfigPHOS(AliSimulation &sim)
 {
   Int_t year = atoi(gSystem->Getenv("CONFIG_YEAR"));
   AliPHOSSimParam *simParam = AliPHOSSimParam::GetInstance();

--- a/MC/SimulationConfig.C
+++ b/MC/SimulationConfig.C
@@ -126,10 +126,12 @@ void SimulationConfig(AliSimulation &sim, ESimulation_t tag)
     return;
 
    // Default simulation enabling IonTail/Crosstalk for TPC
-  case kSimulationDefaultIonTail:
-     SimulationDefault(sim);
-     sim.SetMakeSDigits("TPC");
-     return;
+    case kSimulationDefaultIonTail:
+      SimulationDefault(sim);
+      if (year < 2015) sim.SetMakeSDigits("TPC TRD TOF PHOS HMPID EMCAL MUON ZDC PMD T0 VZERO FMD");
+      else             sim.SetMakeSDigits("TPC TRD TOF PHOS HMPID EMCAL MUON ZDC PMD T0 VZERO FMD AD");
+      sim.SetMakeDigitsFromHits("ITS");
+      return;
   }
 
 }


### PR DESCRIPTION
* Enabling TPC Hits->SDigits->Digits
  * current default for TPC is Hits->Digits
* adding void to the function invocation (Optional?)
  * correct C
  * otherwise my editor was highlighting large faction of code as syntax error