### PR TITLE
OCDB time machine functionality

### DIFF
--- a/MC/OCDBConfig.C
+++ b/MC/OCDBConfig.C
@@ -49,6 +49,21 @@ OCDBDefault(Int_t mode)
   Int_t run  = atoi(gSystem->Getenv("CONFIG_RUN"));  
   AliCDBManager* man = AliCDBManager::Instance();
   man->SetDefaultStorage("raw://");
+  
+  if(gSystem->Getenv("CONFIG_OCDBTIMESTAMP"))
+  {
+    TString t = gSystem->Getenv("CONFIG_OCDBTIMESTAMP");
+    TObjArray* list =t.Tokenize("_");
+    UInt_t tU[6];
+    for(Int_t i=0; i<list->GetEntries(); i++)
+    {
+      TString st = ((TObjString)list->At(i)).GetString();
+      tU[i] =(UInt_t)atoi(st.Data());
+    }
+    man->SetMaxDate(TTimeStamp(tU[0], tU[1], tU[2], tU[3], tU[4], tU[5]));
+    printf("*** Setting custom OCDB time stamp %s ***\n", t.Data());
+  }
+  
   man->SetRun(run);
   
   // set detector specific paths

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -156,6 +156,7 @@ CONFIG_FASTB=""
 CONFIG_VDT=""
 CONFIG_MATERIAL=""
 CONFIG_REMOVETRACKREFS=""
+CONFIG_OCDBTIMESTAMP=""
 
 RUNMODE=""
 
@@ -348,6 +349,9 @@ while [ ! -z "$1" ]; do
     elif [ "$option" = "--removeTrackRefs" ]; then
         CONFIG_REMOVETRACKREFS="on"
 	export CONFIG_REMOVETRACKREFS
+    elif [ "$option" = "--OCDBTimeStamp" ]; then
+        CONFIG_OCDBTIMESTAMP="$1"
+        export CONFIG_OCDBTIMESTAMP
 #    elif [ "$option" = "--sdd" ]; then
 #        RUNMODE="SDD"
 #	export RUNMODE


### PR DESCRIPTION
Added an optional argument to dpgsim, --OCDBTimeStamp which should be in the form <year>_<month>_<day>_<hour>_<minutes>_<seconds> and parsed in the OCDBConfig.C