### PR TITLE
Using new AliGenCocktail mode for RsnNcl production

### DIFF
--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_RsnNcl001.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_RsnNcl001.C
@@ -1,4 +1,6 @@
 struct particle_inj {
+  int n;
+  TString name;
   int pdg;
   double maxpt;
   double maxy;
@@ -13,29 +15,33 @@ GeneratorCustom()
   ctl->AddGenerator(py8, "Pythia8 (Monash2013)", 1.);
 
   // randomly injected particles
-  const int nParticles = 12;
-  particle_inj particleList[12] = { // {pdgcode,maxpt,maxy},
-    {1000010020,6.,0.82},   // Deuteron
-    {-1000010020,6.,0.82},  // Anti-Deuteron
-    {1000010030,6.,0.82},   // Triton
-    {-1000010030,6.,0.82},  // Anti-Triton
-    {1000020030,6.,0.82},   // 3He
-    {-1000020030,6.,0.82},  // Anti-3He
-    {1010010030,10.,0.82},  // Hypertriton
-    {-1010010030,10.,0.82}, // Anti-Hypertriton
-    {225,15.,0.6},          // f2(1270)
-    {3124,15.,0.6},         // Lambda(1520)
-    {-3124,15.,0.6},        // Lambda_bar(1520)
-    {9010221,15.,0.6}       // f0(980)
+  const int nParticles = 16;
+  particle_inj particleList[16] = { // {name,pdgcode,maxpt,maxy},
+    {1,"deuteron",1000010020,6.,0.82},
+    {1,"anti-deuteron",-1000010020,6.,0.82},
+    {1,"triton",1000010030,6.,0.82},
+    {1,"anti-triton",-1000010030,6.,0.82},
+    {1,"3He",1000020030,6.,0.82},
+    {1,"anti-3He",-1000020030,6.,0.82},
+    {1,"hypertriton",1010010030,10.,0.82},
+    {1,"anti-hypertriton",-1010010030,10.,0.82},
+    {1,"f2(1270)",225,15.,0.6},
+    {1,"Lambda(1520)",3124,15.,0.6},
+    {1,"Lambda_bar(1520)",-3124,15.,0.6},
+    {1,"f0(980)",9010221,15.,0.6},
+    {1,"Xi*0(1530)",3324,15.,0.6},
+    {1,"Xi*0_bar(1530)",-3324,15.,0.6},
+    {1,"Xi0(1820)",123324,15.,0.6},
+    {1,"Xi0_bar(1820)",-123324,15.,0.6},
+    {1,"Xi-(1820)",123314,15.,0.6},
+    {1,"Xi+(1820)",-123314,15.,0.6}
   };
 
-  const int idx = uidConfig % nParticles;
-
-  Int_t pdg = particleList[idx].pdg; // select according to unique ID
-  AliGenerator   *inj = GeneratorInjector(1, particleList[idx].pdg, 0., particleList[idx].maxpt,
-     -particleList[idx].maxy, particleList[idx].maxy);
-  ctl->AddGenerator(inj, "Injector (RsnNcl001)", 1.);
-  //
+  ctl->UseSingleInjectionPerEvent();
+  for (int idx = 0; idx < nParticles; ++idx) {
+    AliGenerator   *inj = GeneratorInjector(particleList[idx].n, particleList[idx].pdg, 0., particleList[idx].maxpt,-particleList[idx].maxy, particleList[idx].maxy);
+    ctl->AddGenerator(inj, (particleList[idx].name + " injector").Data(), 1.);
+  }
   return ctl;
 }
 

--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_RsnNcl001.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_RsnNcl001.C
@@ -15,8 +15,8 @@ GeneratorCustom()
   ctl->AddGenerator(py8, "Pythia8 (Monash2013)", 1.);
 
   // randomly injected particles
-  const int nParticles = 16;
-  particle_inj particleList[16] = { // {name,pdgcode,maxpt,maxy},
+  const int nParticles = 18;
+  particle_inj particleList[18] = { // {name,pdgcode,maxpt,maxy},
     {1,"deuteron",1000010020,6.,0.82},
     {1,"anti-deuteron",-1000010020,6.,0.82},
     {1,"triton",1000010030,6.,0.82},


### PR DESCRIPTION
This PR adapts the RsnNcl generator to the new AliGenCocktail mode that allows the user to use a single generator on top of a background event choosing randomly from the list of the generators. This new mode, as well as this generator, will be working with AliRoot master as soon as [this pr](https://github.com/alisw/AliRoot/pull/512) will be merged.

Cheers,
Max