### PR TITLE
Therminator2: preparing script and macro to handle new path formats

### DIFF
--- a/MC/CustomGenerators/PWGCF/Therminator2_001.C
+++ b/MC/CustomGenerators/PWGCF/Therminator2_001.C
@@ -1,4 +1,4 @@
-AliGenerator * GeneratorCustom() {
+AliGenerator * GeneratorCustom(string xmlPath) {
 
   // ====================================================
   // set environment variables
@@ -6,8 +6,9 @@ AliGenerator * GeneratorCustom() {
   // select 3+1 hydro model
   gSystem->Setenv("THERM2_PARAMS_FreezeOutModel", "Lhyquid3D");
 
-  // xml path for Pb-Pb at 2.76 TeV (0-5%)
-  gSystem->Setenv("THERM2_PARAMS_XML_PATH", "alien:/alice/cern.ch/user/m/mbuczyns/Therminator2_custom_hypersurface/lhyquid3v/LHCPbPb2760b2.3Ti512t0.60Tf140a0.08b0.08h0.24x2.3v2.xml");
+  // expand and set freezeout xml path for the selected model
+  string path = AliDataFile::GetFileName(xmlPath);
+  gSystem->Setenv("THERM2_PARAMS_XML_PATH", path.c_str());
   
   // ====================================================
   // create Therminator2 generator

--- a/MC/CustomGenerators/PWGCF/Therminator2_001.C
+++ b/MC/CustomGenerators/PWGCF/Therminator2_001.C
@@ -1,4 +1,4 @@
-AliGenerator * GeneratorCustom(string xmlPath) {
+AliGenerator * GeneratorCustom(TString xmlPath) {
 
   // ====================================================
   // set environment variables
@@ -7,8 +7,10 @@ AliGenerator * GeneratorCustom(string xmlPath) {
   gSystem->Setenv("THERM2_PARAMS_FreezeOutModel", "Lhyquid3D");
 
   // expand and set freezeout xml path for the selected model
-  string path = AliDataFile::GetFileName(xmlPath);
-  gSystem->Setenv("THERM2_PARAMS_XML_PATH", path.c_str());
+  string fullPath = AliDataFile::GetFileName(xmlPath.Data());
+  if(fullPath == "")
+    fullPath = xmlPath;
+  gSystem->Setenv("THERM2_PARAMS_XML_PATH", fullPath.c_str());
   
   // ====================================================
   // create Therminator2 generator

--- a/MC/CustomGenerators/PWGCF/Therminator2_001.C
+++ b/MC/CustomGenerators/PWGCF/Therminator2_001.C
@@ -6,11 +6,8 @@ AliGenerator * GeneratorCustom(TString xmlPath) {
   // select 3+1 hydro model
   gSystem->Setenv("THERM2_PARAMS_FreezeOutModel", "Lhyquid3D");
 
-  // expand and set freezeout xml path for the selected model
-  string fullPath = AliDataFile::GetFileName(xmlPath.Data());
-  if(fullPath == "")
-    fullPath = xmlPath;
-  gSystem->Setenv("THERM2_PARAMS_XML_PATH", fullPath.c_str());
+  // set freezeout xml path for the selected model
+  gSystem->Setenv("THERM2_PARAMS_XML_PATH", xmlPath.Data());
   
   // ====================================================
   // create Therminator2 generator

--- a/MC/EXTRA/gen_therm2.sh
+++ b/MC/EXTRA/gen_therm2.sh
@@ -22,12 +22,12 @@ function setFreezeoutXml
     then
         # Downloading the GRID file to fomodel/
         alien_cp $1 fomodel/
-
-        BASENAME=$(basename $1)
-        export THERM2_PARAMS_FreezeFile="$BASENAME"
     else
-        export THERM2_PARAMS_FreezeFile="$1"
+        # If it's not a GRID path, just copy the file to fomodel
+        cp $1 fomodel/
     fi
+    BASENAME=$(basename $1)
+    export THERM2_PARAMS_FreezeFile="$BASENAME"
 
 } 
 

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -1368,7 +1368,7 @@ GeneratorTherminator2()
     //gSystem->Setenv("THERM2_PARAMS_FreezeOutModel", "BWAVT");
 
     // Example of setting a local xml path for the hydro model
-    //gSystem->Setenv("THERM2_PARAMS_XML_PATH", "lhyquid2dbi/LHCPbPb5500c0005Ti500ti100Tf145.xml");
+    //gSystem->Setenv("THERM2_PARAMS_XML_PATH", "fomodel/lhyquid2dbi/LHCPbPb5500c0005Ti500ti100Tf145.xml");
 
     // Example of setting a GRID xml path for the hydro model
     //gSystem->Setenv("THERM2_PARAMS_XML_PATH", "alien:/alice/<rest_of_GRID_PATH>");


### PR DESCRIPTION
I've modified the generation script to handle full xml file paths.

The Therminator2 AliGenerator macro is now taking a path parameter for more flexibility. The given path is then expanded using `AliDataFile::GetFileName()` which allows for relative paths, such as `"PWGCF/file.xml"`.