### PR TITLE
Fix string size in struct for the resonance generator

### DIFF
--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn002.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn002.C
@@ -1,6 +1,6 @@
 struct particle_inj {
   int n;
-  TString name;
+  char name[32];
   int pdg;
   double maxpt;
   double maxy;
@@ -29,11 +29,12 @@ AliGenerator* GeneratorCustom()
   };
 
   AliDecayerPythia *dec = new AliDecayerPythia;
+  AliPDG::AddParticlesToPdgDataBase();
 
   ctl->UseSingleInjectionPerEvent();
   for (int idx = 0; idx < nParticles; ++idx) {
     AliGenerator   *inj = GeneratorParam(particleList[idx].n, particleList[idx].pdg, 0., particleList[idx].maxpt,-particleList[idx].maxy, particleList[idx].maxy,dec);
-    ctl->AddGenerator(inj, (particleList[idx].name + " injector").Data(), 1.);
+    ctl->AddGenerator(inj, (TString(particleList[idx].name) + " injector").Data(), 1.);
   }
   return ctl;
 }


### PR DESCRIPTION
Hi @miweberSMI @catalinristea ,

this fixes the issue discovered on the grid for the resonance generator.
In my local tests it is working, but it was the case also for the previous one... This time I checked also on lxplus and it should be OK. Please have a look!

Cheers,
Max