### PR TITLE
Add generator for Herwig7

### DIFF
--- a/MC/CustomGenerators/PWGJE/LHC-MB.tmpl
+++ b/MC/CustomGenerators/PWGJE/LHC-MB.tmpl
@@ -1,0 +1,53 @@
+# -*- ThePEG-repository -*-
+
+################################################################################
+# This file contains our best tune to UE data from ATLAS at 7 TeV. More recent
+# tunes and tunes for other centre-of-mass energies as well as more usage
+# instructions can be obtained from this Herwig wiki page:
+# http://projects.hepforge.org/herwig/trac/wiki/MB_UE_tunes
+################################################################################
+
+##################################################
+# Technical parameters for this run
+##################################################
+cd /Herwig/Generators
+set LHCGenerator:NumberOfEvents {{ CONFIG_NEVENTS }} 
+set LHCGenerator:RandomNumberGenerator:Seed {{ CONFIG_SEED }}
+set LHCGenerator:PrintEvent 10
+set LHCGenerator:MaxErrors 1000000
+
+set LHCGenerator:DebugLevel 0
+set LHCGenerator:DumpPeriod -1
+set LHCGenerator:DebugEvent 0
+
+
+##################################################
+# LHC physics parameters (override defaults here) 
+##################################################
+set LHCGenerator:EventHandler:LuminosityFunction:Energy {{ CONFIG_ENERGY }}
+
+# Intrinsic pT tune extrapolated to LHC energy
+set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.2*GeV
+
+##################################################
+# Matrix Elements for hadron-hadron collisions 
+##################################################
+cd /Herwig/MatrixElements/
+insert SimpleQCD:MatrixElements[0] MEMinBias
+
+
+# MPI model settings
+set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE 0
+cd /Herwig/Generators
+
+# Change to have no pT cuts for MinBias
+set LHCGenerator:EventHandler:Cuts /Herwig/Cuts/MinBiasCuts
+
+insert LHCGenerator:AnalysisHandlers 0 /Herwig/Analysis/HepMCFile
+set /Herwig/Analysis/HepMCFile:Format GenEvent
+set /Herwig/Analysis/HepMCFile:Units GeV_mm
+set /Herwig/Analysis/HepMCFile:PrintEvent {{ CONFIG_NEVENTS }}
+set /Herwig/Analysis/HepMCFile:Filename output.hepmc
+
+run LHC-MB LHCGenerator
+

--- a/MC/EXTRA/gen_herwig.sh
+++ b/MC/EXTRA/gen_herwig.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+set -e
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: gen_eposlhc_PbPb.sh [outfilename] [nevents] [projectile_id] [projectile_energy] [target_id] [target_energy]"
+    exit -1
+fi
+
+echo "running in `pwd`, writing HepMC to $1"
+
+# prepare environment
+source /cvmfs/alice.cern.ch/etc/login.sh
+eval $(alienv printenv Herwig/v7.0.4-alice1-3)
+export LHAPDF_DATA_PATH=$LHAPDF_ROOT/share/LHAPDF
+
+$ALIDPG_ROOT/MC/EXTRA/generate_matchbox_from_template.py $ALIDPG_ROOT/MC/CustomGenerators/PWGJE/LHC-MB.tmpl
+Herwig read --repo=$HERWIG_ROOT/share/Herwig/HerwigDefaults.rpo LHC-MB.in
+
+cat output.hepmc >> $1

--- a/MC/EXTRA/generate_matchbox_from_template.py
+++ b/MC/EXTRA/generate_matchbox_from_template.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python
+
+import os
+import sys
+import jinja2
+
+def render_matchbox(matchbox_template_path, context):
+  path, filename = os.path.split(matchbox_template_path)
+  return jinja2.Environment(
+    loader=jinja2.FileSystemLoader(path or './')
+  ).get_template(filename).render(context)
+
+def generate_matchbox_from_template(templatename):
+  matchboxname = os.path.basename(templatename)
+  matchboxname = matchboxname.replace(".tmpl", ".in")
+  # decode configuration parameters from environment variables set by AliDPG
+  configparams = {}
+  for k, v in os.environ.items():
+    if "CONFIG" in k:
+      configparams[k] = v
+
+  with open(matchboxname, 'w') as matchboxwriter:
+    rendered = render_matchbox(templatename, configparams)
+    #print(rendered)
+    matchboxwriter.write(rendered)
+
+if __name__ == "__main__":
+  generate_matchbox_from_template(sys.argv[1])  

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -40,6 +40,8 @@ enum EGenerator_t {
   kGeneratorAMPT, kGeneratorAMPT_v226t7,
   // Therminator2
   kGeneratorTherminator2,
+  // Herwig7
+  kGeneratorHerwig7,
   //
   kGeneratorCustom,
   //
@@ -79,6 +81,8 @@ const Char_t *GeneratorName[kNGenerators] = {
   "AMPT", "AMPT_v226t7",
   // Therminator2
   "Therminator2",
+  // Herwig7
+  "Herwig7",
   //
   "Custom",
   //
@@ -181,6 +185,7 @@ AliGenerator *GeneratorPythia8JetsGammaTrg(Int_t tune = 0, Int_t acceptance = kC
 AliGenerator *GeneratorPythia8GammaJet(Int_t tune = 0, Int_t acceptance = kCalorimeterAcceptance_FullDetector);
 AliGenerator *GeneratorPhojet();
 AliGenerator *GeneratorEPOSLHC();
+AliGenerator *GeneratorHerwig7();
 AliGenerator *GeneratorHijing();
 AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac);
 AliGenerator *Generator_Nuclex(UInt_t injbit, Bool_t antiparticle, Int_t ninj, Float_t max_pt = 10.f, Float_t max_y = 1.);
@@ -298,6 +303,10 @@ void GeneratorConfig(Int_t tag)
 
  case kGeneratorTherminator2:
     gen = GeneratorTherminator2();
+    break;
+
+  case kGeneratorHerwig7:
+    gen = GeneratorHerwig7();
     break;
 
     // Custom
@@ -920,6 +929,27 @@ GeneratorEPOSLHC()
   return gener;
 }
 
+/*** HERWIG7 ***************************************************/
+AliGenerator *
+GeneratorHerwig7()
+{
+  // run Herwig7
+  TString fifoname = "herwigeventfifo";
+  gROOT->ProcessLine(Form(".! rm -rf %s", fifoname.Data()));
+  gROOT->ProcessLine(Form(".! mkfifo %s", fifoname.Data()));
+  gROOT->ProcessLine(Form(".! sh $ALIDPG_ROOT/MC/EXTRA/gen_herwig.sh %s &> gen_herwig.log &",
+          fifoname.Data()));
+
+  //
+  // connect HepMC reader
+  AliGenReaderHepMC *reader = new AliGenReaderHepMC();
+  reader->SetFileName("herwigeventfifo");
+  AliGenExtFile *gener = new AliGenExtFile(-1);
+  gener->SetName(Form("Herwig7_%s", systemConfig.Data()));
+  gener->SetReader(reader);
+  return gener;
+}
+
 /*** HIJING ****************************************************/
 
 AliGenerator * 
@@ -1472,17 +1502,19 @@ GeneratorInjector(Int_t ninj, Int_t pdg, Float_t ptmin, Float_t ptmax, Float_t y
   return box;
 }
 
+
 /*** PARAMETRIC INJECTOR ****************************************/
 AliGenParam* GeneratorParam(int n, int pdg, double ptmin, double ptmax, double ymin, double ymax, AliDecayer* dec, double phimin, double phimax) {
   comment = comment.Append(Form(" | injected (pdg=%d, %d particles)", pdg, n));
+/*
   AliGenParam* gen = new AliGenParam(Form("%i",pdg), n, pdg);
   gen->SetYRange(ymin,ymax);
   gen->SetPtRange(ptmin,ptmax);
   gen->SetPhiRange(phimin,phimax);
   if (dec) gen->SetDecayer(dec);
-  return gen;
+*/
+  return 0x0;
 }
-
 
 
 /*** JPSI -> EE ****************************************************/


### PR DESCRIPTION
Events are generated with the Herwig7
executable in an external process and
read in AlRoot with AliGenReaderHepMC.
Config files for Herwig are handled
as template files replacing instances
of CONFIG* with the corresponding
environment variables set by dpgsim.sh.
Translation of the templates into
Matchbox files is done using JINJA.
Initially a template is provided for
Min. Bias pp, more templates eventually
to be added in the future.