### PR TITLE
Fixes for ROOT6

### DIFF
--- a/MC/Config.C
+++ b/MC/Config.C
@@ -45,7 +45,7 @@ static Bool_t  isGeant4        = kFALSE;    // geant4 flag
 static Bool_t  purifyKine      = kTRUE;     // purifyKine flag
 static Bool_t  isFluka         = kFALSE;    // fluka flag
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
 #include "MC/DetectorConfig.C"
 #include "MC/GeneratorConfig.C"
 #endif
@@ -61,7 +61,7 @@ Config()
 {
 
   /* initialise */
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else  
   gROOT->LoadMacro("$ALIDPG_ROOT/MC/DetectorConfig.C");
@@ -102,7 +102,7 @@ Config()
   printf(">>>>>            fluka: %d \n", isFluka);
   printf(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n");
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else  
   LoadLibraries();
@@ -371,7 +371,7 @@ ProcessEnvironment()
 
 }
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else
 LoadLibraries()

--- a/MC/DetectorConfig.C
+++ b/MC/DetectorConfig.C
@@ -75,6 +75,7 @@ Int_t iFIT    = 0;
   
 void DetectorDefault();
 void DetectorMuon();
+void DetectorRun3();
 void DetectorInit(Int_t tag);
 void DetectorInitRun3(Int_t tag);
 

--- a/MC/Geant4Config.C
+++ b/MC/Geant4Config.C
@@ -1,4 +1,4 @@
-Geant4Config()
+void Geant4Config()
 {
 
   if (gClassTable->GetID("TGeant4") == -1) {

--- a/MC/SimulationConfig.C
+++ b/MC/SimulationConfig.C
@@ -54,7 +54,7 @@ const Char_t *SimulationName[kNSimulations] = {
 void SimulationDefault(AliSimulation &sim);
 void SimulationConfigPHOS(AliSimulation &sim);
 void SimulationRun3(AliSimulation &sim);
-void AddDetToGRPRun3(AliDAQ::DetectorBits det, int run);
+void AddDetToGRPRun3(AliDAQ::DetectorBits detAdd, AliDAQ::DetectorBits detRem, int run);
 void SetCDBRun3(int run);
 
 AliSimulation* gg_tmp_sim;
@@ -169,7 +169,8 @@ void SimulationConfig(AliSimulation &sim, ESimulation_t tag)
    // Default simulation enabling IonTail/Crosstalk for TPC
   case kSimulationDefaultIonTail:
       SimulationDefault(sim);
-      Int_t year = atoi(gSystem->Getenv("CONFIG_YEAR"));
+      Int_t year;
+      year = atoi(gSystem->Getenv("CONFIG_YEAR"));
       if (year < 2015) sim.SetMakeSDigits("TPC TRD TOF PHOS HMPID EMCAL MUON ZDC PMD T0 VZERO FMD");
       else             sim.SetMakeSDigits("TPC TRD TOF PHOS HMPID EMCAL MUON ZDC PMD T0 VZERO FMD AD");
       sim.SetMakeDigitsFromHits("ITS");
@@ -292,7 +293,7 @@ void SimulationRun3(AliSimulation &sim)
   sim.SetRunQA(":");
   //
   printf("Adding new detectors to GRP and suppressing HLT\n");
-  AddDetToGRPRun3(AliDAQ::kMFT | AliDAQ::kFIT, AliDAQ::kHLT, runNumber); // recreate GRP
+  AddDetToGRPRun3((AliDAQ::DetectorBits)(AliDAQ::kMFT | AliDAQ::kFIT), AliDAQ::kHLT, runNumber); // recreate GRP
   AliCDBManager* man = AliCDBManager::Instance();
   man->ClearCache();
   man->SetSpecificStorage("GRP/GRP/Data", "local://./");


### PR DESCRIPTION
 Some small stuff (missing forward declaration, incorrect forward declaration). In Config.C consequently the ROOT5 code was executed under ROOT6 and vice versa. In case of doubts that the ROOT_VERISON_CODE macro works under ROOT5 in interpreted mode (what one can deduce from the comments) I recomment to use the "__CLING__" macro -  this has been verified that it properly separates the ROOT5 and ROOT6 case also in interpreted mode.