### PR TITLE
 load AMPT from nightly builds

### DIFF
--- a/MC/EXTRA/gen_ampt.sh
+++ b/MC/EXTRA/gen_ampt.sh
@@ -9,8 +9,7 @@ fi
 echo "running in `pwd`, writing HepMC to $1"
 
 # prepare environment
-source /cvmfs/alice.cern.ch/etc/login.sh
-eval $(alienv printenv AMPT::v1.26t7-v2.26t7-1)
+eval $(/cvmfs/alice-nightlies.cern.ch/bin/alienv printenv AMPT::v1.26t7-v2.26t7-alice1_PWGMMTEST-2)
 
 # run generator
 


### PR DESCRIPTION
Hi @miweberSMI ,

We have a new (nightly) build of AliGenerators, so we can now use AMPT with the HIJING patch from there. This PR configures AMPT for AliDPG such that it will use this new tag of AliGenerators . For testing it, I think we need a new tag of AliDPG. 

The new build of AliGenerators also contains the updated version of Therminator2, so if we request a new tag of AliDPG, it's better to wait also for the updated AliDPG scripts for Therminator2 and fix the two problems in one go. Currently I cannot make a PR for this, as it would conflict with #111 . If you merge #111 , I can open a new PR for Therminator2. Otherwise I would ask @maciekniewielki  to amend #111 .

Thanks,

Redmer