### PR TITLE
Fixes for running AliDPG MC with Root 6

### DIFF
--- a/MC/Config.C
+++ b/MC/Config.C
@@ -46,8 +46,8 @@ static Bool_t  purifyKine      = kTRUE;     // purifyKine flag
 static Bool_t  isFluka         = kFALSE;    // fluka flag
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
-#include "MC/DetectorConfig.C"
-#include "MC/GeneratorConfig.C"
+#include "DetectorConfig.C"
+#include "GeneratorConfig.C"
 #endif
 
 void ProcessEnvironment();

--- a/MC/CreateSnapshot.C
+++ b/MC/CreateSnapshot.C
@@ -89,7 +89,7 @@ void CreateSnapshot(Int_t mode)
 
   TString ocdbRun3 = gSystem->Getenv("CONFIG_OCDBRUN3");
 
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else
   if(ocdbRun3.IsNull())

--- a/MC/CreateSnapshot.C
+++ b/MC/CreateSnapshot.C
@@ -92,13 +92,11 @@ void CreateSnapshot(Int_t mode)
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else
-  if(ocdbRun3.IsNull())
-    gROOT->LoadMacro("$ALIDPG_ROOT/MC/OCDBConfig.C");
-  else
-    gROOT->LoadMacro("$ALIDPG_ROOT/MC/OCDBRun3.C");
+  gROOT->LoadMacro("$ALIDPG_ROOT/MC/OCDBConfig.C");
 #endif
-  
+
   if(!ocdbRun3.IsNull()){
+    gROOT->LoadMacro("$ALIDPG_ROOT/MC/OCDBRun3.C");
     gROOT->ProcessLine(Form("OCDBRun3(%d);",mode));
   }
   else{

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -611,7 +611,7 @@ GeneratorPythia6Heavy(Int_t process, Int_t decay, Int_t tune, Bool_t HFonly)
     pythia->SetHeavyQuarkYRange(-1.5, 1.5);
     break;
   case kPythia6HFYellowReport:
-    pythia->SetHeavyQuarkYRange(-1.5, 1.5)
+    pythia->SetHeavyQuarkYRange(-1.5, 1.5);
     pythia->SetForceDecay(kHFYellowReport);
     break;
   }

--- a/MC/ReconstructionConfig.C
+++ b/MC/ReconstructionConfig.C
@@ -447,9 +447,9 @@ void SetCDBRun3(int run)
 {
   // set OCDB source
   TString ocdbConfig = "default,snapshot";
+  AliCDBManager *cdbm = AliCDBManager::Instance();
   if (!gSystem->AccessPathName("OCDBrec.root")) {
     // set OCDB snapshot mode
-    AliCDBManager *cdbm = AliCDBManager::Instance();
     cdbm->SetSnapshotMode("OCDBrec.root");
     cdbm->SetDefaultStorage("local://");
     //    cdbm->SetSnapshotMode("OCDBsim.root");

--- a/MC/rec.C
+++ b/MC/rec.C
@@ -16,7 +16,7 @@ void rec()
 {
 
   // reconstruction configuration
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else  
   gROOT->LoadMacro("$ALIDPG_ROOT/MC/ReconstructionConfig.C");

--- a/MC/sim.C
+++ b/MC/sim.C
@@ -26,7 +26,7 @@ void sim()
   if (gSystem->Getenv("CONFIG_NEVENTS"))
     nev = atoi(gSystem->Getenv("CONFIG_NEVENTS"));
   
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
 #else
   gROOT->LoadMacro("$ALIDPG_ROOT/MC/SimulationConfig.C");


### PR DESCRIPTION
This PR combines a couple of fixes I had to apply to run AliDPG simulation with Root 6.
I am not 100% sure about the include paths. For me, it worked to remove the "MC/" before the files, but I think one could alternatively set a ROOT_INCLUDE_PATH to the AliDPG root, no idea what is better.