### PR TITLE
Updating Therminator2 version in the generator script

### DIFF
--- a/MC/EXTRA/gen_therm2.sh
+++ b/MC/EXTRA/gen_therm2.sh
@@ -102,7 +102,7 @@ fi
 echo "running in `pwd`, writing HepMC to $1"
 
 # prepare environment
-eval $(/cvmfs/alice.cern.ch/bin/alienv printenv Therminator2::v2.0.3-alice1-1)
+eval $(/cvmfs/alice.cern.ch/bin/alienv printenv Therminator2::v2.0.3-alice2-1)
 
 if [ -d events/ ];
 then


### PR DESCRIPTION
The fixed version of the Therminator2 generator has been released (see [here](https://alice.its.cern.ch/jira/browse/ALIROOT-7952)). I'm updating the generator script to include this change.