### PR TITLE
Fix missing include for kPythia6HFYellowReport

### DIFF
--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -6,6 +6,7 @@
  
 #if !(defined(__CLING__)  || defined(__CINT__)) || defined(__ROOTCLING__) || defined(__ROOTCINT__)
 #include "AliGenPythia.h"
+#include "AliDecayer.h"
 #endif
 
 enum EGenerator_t {


### PR DESCRIPTION
This include is needed when running the macro in ROOT 6, thanks to @chiarazampolli for pointing to the missing header.