### PR TITLE
Fix NULL vs. "" handling in PHOS CaloCells macros

### DIFF
--- a/QA/QAtrain_duo.C
+++ b/QA/QAtrain_duo.C
@@ -68,7 +68,22 @@ void QAtrain_duo(const char *suffix="", Int_t run = 0,
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGPP/HMPID/AddTaskHmpidQA.C");
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGPP/T0/AddTaskT0QA.C");
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/FORWARD/analysis2/AddTaskForwardQA.C");
+
+  // The following macro exists across ROOT versions with two different signatures. We need to know
+  // which one we are using. Note that checking the AliRoot version is weak (since we may not have
+  // a variable holding the version, for instance during development). We ask the interpreter to
+  // process a define directive. The directive is processed before we invoke the corresponding
+  // main_QAtrain_duo.C macro, and expanded properly there, in both ROOT 5 and 6
+  if (gSystem->Exec("grep -q 'char* fname' $ALICE_PHYSICS/PWGGA/PHOSTasks/CaloCellQA/macros/AddTaskCaloCellsQA.C") == 0) {
+    // Using the old version (with char* fname, accepting NULL as value)
+    gInterpreter->ProcessLine("#define CALOCELLS_NULL 0x0");
+  }
+  else {
+    // We expect any other version to support "" for empty strings
+    gInterpreter->ProcessLine("#define CALOCELLS_NULL \"\"");
+  }
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGGA/PHOSTasks/CaloCellQA/macros/AddTaskCaloCellsQA.C");
+
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGGA/PHOSTasks/PHOS_PbPbQA/macros/AddTaskPHOSPbPb.C");
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGGA/PHOSTasks/PHOS_TriggerQA/macros/AddTaskPHOSTriggerQA.C");
   //gROOT->LoadMacro("$ALICE_PHYSICS/PWGGA/EMCALTasks/macros/AddTaskEMCALTriggerQA.C"); // obsolete
@@ -80,16 +95,16 @@ void QAtrain_duo(const char *suffix="", Int_t run = 0,
 
   // loading the libraries (needed for ROOT5)
   gROOT->Macro("$ALIDPG_ROOT/DataProc/Common/LoadLibraries.C");
-  
+
   // running the main macro
 if (gSystem->AccessPathName("main_QAtrain_duo.C", kFileExists)==0) {
     Printf("Using local main_QAtrain_duo.C");
     gROOT->Macro(TString::Format("main_QAtrain_duo.C(\"%s\", %d, \"%s\", %d, \"%s\")", suffix, run, xmlfile, stage, cdb));
   }
   else {
-    Printf("Using main_QAtrain_duo.C from AliDPG");    
+    Printf("Using main_QAtrain_duo.C from AliDPG");
     gROOT->Macro(TString::Format("$ALIDPG_ROOT/QA/main_QAtrain_duo.C(\"%s\", %d, \"%s\", %d, \"%s\")", suffix, run, xmlfile, stage, cdb));
-  }  
+  }
 
   return;
 

--- a/QA/main_QAtrain_duo.C
+++ b/QA/main_QAtrain_duo.C
@@ -212,7 +212,6 @@ void AddAnalysisTasks(const char *suffix, const char *cdb_location)
   // PHOS QA tasks need different arguments starting for AliPhysics >= v5-09-24
   // we expect by default to be using an AliPhysics recent than the two above
   Bool_t disableESDtrackQA=kFALSE;
-  Bool_t useEmptyStringForPHOS=kTRUE;
 
   if(!gSystem->Getenv("ALIEN_JDL_PACKAGES"))
     if(gSystem->Getenv("ALIEN_PACKAGES"))
@@ -234,10 +233,8 @@ void AddAnalysisTasks(const char *suffix, const char *cdb_location)
     printf("XXXXXXXXX=> %s\n",aliph.Data());
     if(ver<5){
       disableESDtrackQA=kTRUE;
-      useEmptyStringForPHOS=kFALSE;
     }else if(ver==5){
       if(n1<9 || (n1==9 && n2<14)) disableESDtrackQA=kTRUE;  // < v5-09-14
-      if(n1<9 || (n1==9 && n2<24)) useEmptyStringForPHOS=kFALSE;  // < v5-09-24
     }
   }
 
@@ -600,13 +597,11 @@ void AddAnalysisTasks(const char *suffix, const char *cdb_location)
   // 
   if (doPHOS) {
     AliAnalysisTaskCaloCellsQA *taskPHOSCellQA1 = 0x0;
-    if(useEmptyStringForPHOS) taskPHOSCellQA1 = AddTaskCaloCellsQA(5, 1, "","PHOSCellsQA_AnyInt");
-    else taskPHOSCellQA1 = AddTaskCaloCellsQA(5, 1, NULL,"PHOSCellsQA_AnyInt");
+    taskPHOSCellQA1 = AddTaskCaloCellsQA(5, 1, CALOCELLS_NULL,"PHOSCellsQA_AnyInt");
     taskPHOSCellQA1->SelectCollisionCandidates(kTriggerMask);
     taskPHOSCellQA1->GetCaloCellsQA()->SetClusterEnergyCuts(0.3,0.3,1.0);
     AliAnalysisTaskCaloCellsQA *taskPHOSCellQA2 = 0x0;
-    if(useEmptyStringForPHOS)  taskPHOSCellQA2 = AddTaskCaloCellsQA(5, 1, "","PHOSCellsQA_PHI7");
-    else taskPHOSCellQA2 = AddTaskCaloCellsQA(5, 1, NULL,"PHOSCellsQA_PHI7");
+    taskPHOSCellQA2 = AddTaskCaloCellsQA(5, 1, CALOCELLS_NULL,"PHOSCellsQA_PHI7");
     taskPHOSCellQA2->SelectCollisionCandidates(AliVEvent::kPHI7);
     taskPHOSCellQA2->GetCaloCellsQA()->SetClusterEnergyCuts(0.3,0.3,1.0);
     // Pi0 QA fo PbPb
@@ -623,17 +618,10 @@ void AddAnalysisTasks(const char *suffix, const char *cdb_location)
     AliAnalysisTaskPHOSTriggerQA* taskPHOSTrig2 = 0x0;
     AliAnalysisTaskPHOSTriggerQA* taskPHOSTrig3 = 0x0;
     AliAnalysisTaskPHOSTriggerQA* taskPHOSTrig4 = 0x0;
-    if(useEmptyStringForPHOS){
-      taskPHOSTrig1 = AddTaskPHOSTriggerQA("","PHOSTriggerQAResultsL0");
-      taskPHOSTrig2 = AddTaskPHOSTriggerQA("","PHOSTriggerQAResultsL1High");
-      taskPHOSTrig3 = AddTaskPHOSTriggerQA("","PHOSTriggerQAResultsL1Medium");
-      taskPHOSTrig4 = AddTaskPHOSTriggerQA("","PHOSTriggerQAResultsL1Low");
-    }else{
-      taskPHOSTrig1 = AddTaskPHOSTriggerQA(NULL,"PHOSTriggerQAResultsL0");
-      taskPHOSTrig2 = AddTaskPHOSTriggerQA(NULL,"PHOSTriggerQAResultsL1High");
-      taskPHOSTrig3 = AddTaskPHOSTriggerQA(NULL,"PHOSTriggerQAResultsL1Medium");
-      taskPHOSTrig4 = AddTaskPHOSTriggerQA(NULL,"PHOSTriggerQAResultsL1Low");
-    }
+    taskPHOSTrig1 = AddTaskPHOSTriggerQA(CALOCELLS_NULL,"PHOSTriggerQAResultsL0");
+    taskPHOSTrig2 = AddTaskPHOSTriggerQA(CALOCELLS_NULL,"PHOSTriggerQAResultsL1High");
+    taskPHOSTrig3 = AddTaskPHOSTriggerQA(CALOCELLS_NULL,"PHOSTriggerQAResultsL1Medium");
+    taskPHOSTrig4 = AddTaskPHOSTriggerQA(CALOCELLS_NULL,"PHOSTriggerQAResultsL1Low");
     taskPHOSTrig2->SelectL1Threshold(0);
     taskPHOSTrig3->SelectL1Threshold(1);
     taskPHOSTrig4->SelectL1Threshold(2);


### PR DESCRIPTION
Task `AliAnalysisTaskCaloCellsQA` exists with two different signatures. We need
to know which one we are using. Note that checking the AliRoot version is weak
(since we may not have a variable holding the version, for instance during
development). We now:

* check the macro file for the presence of the old signature,
* define a preprocessor directive accordingly (via `gInterpreter`).

The directive is processed before we invoke the corresponding
`main_QAtrain_duo.C` macro, and expanded properly there, in both ROOT 5 and 6.

Note that the old strategies are wrong/faulty for different reasons:

* conditionally checking the value of a boolean _at runtime_ does not prevent
  ROOT 6 from still processing the lines it won't actually execute, leading to
  errors for the incorrect signatures,
* loading the correct signature based on the ROOT version is wrong, since the
  change has been made in AliPhysics and it was already in use with the new
  signature for AliRoot ROOT 5-based versions