### PR TITLE
Add script to run CompareAllHistos.C

### DIFF
--- a/Utils/CompareAllHistos.C
+++ b/Utils/CompareAllHistos.C
@@ -66,7 +66,7 @@ void CompareAllHistos(TString filename="QAresults_v5-09-35.root", TString filena
 
 void ProcessFile(TString fname, TString dirToAnalyse){
 
-  TFile *fileBase=new TFile(fname.Data());
+  TFile *fileBase=TFile::Open(fname.Data());
   Int_t nkeys=fileBase->GetNkeys();
   TList* lkeys=fileBase->GetListOfKeys();
   for(Int_t j=0; j<nkeys; j++){

--- a/Utils/runCompareAllHistos.sh
+++ b/Utils/runCompareAllHistos.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+exec > >(tee "compare_all_histos.txt") 2>&1
+cd "$(dirname "$0")"
+echo "Current QAresults: $1"
+echo "Comparing to: $COMPARE_QARESULTS"
+set -x
+root -b -l -q "CompareAllHistos.C(\"$1\", \"$COMPARE_QARESULTS\", \"\");"


### PR DESCRIPTION
We also allow CompareAllHistos.C to read files from any source instead of just
supporting local files by using `TFile::Open()` instead of `new TFile()`

@chiarazampolli @fprino