### PR TITLE
Don't run the CheckESD for now.

### DIFF
--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -860,13 +860,16 @@ if [[ $CONFIG_MODE == *"rec"* ]] || [[ $CONFIG_MODE == *"full"* ]]; then
 
 # ESD tag creation removed on September 2017 after CB and PB discussions
 
-
-    CHECKESDC=$ALIDPG_ROOT/MC/CheckESD.C
-    if [ -f CheckESD.C ]; then
-	CHECKESDC=CheckESD.C
-    fi
-    runcommand "CHECK ESD" $CHECKESDC check.log 60 1
-
+    # Commenting out the CheckESD while we sort out how to configure
+    # the PID response properly. In any case, the output of this check is
+    # neither checked nor stored at present
+#    CHECKESDC=$ALIDPG_ROOT/MC/CheckESD.C
+#    if [ -f CheckESD.C ]; then
+#	CHECKESDC=CheckESD.C
+#    fi
+#    runcommand "CHECK ESD" $CHECKESDC check.log 60 1
+#
+    
     # delete files not needed anymore
     if [[ $CONFIG_SIMULATION == "EmbedBkg" ]]; then
 	rm -f *.RecPoints.root *.Digits.root


### PR DESCRIPTION
We need to converge on how to set the PID response in the macro.
Since currently the output of this macro is not looked at and not
even saved, it is ok to not run it.
See also discussion in https://github.com/alisw/AliDPG/commit/52bc50b3b690e4265406d8518a91e6adcccb5067#diff-110caea4b0dcf9bdb2a94892627e82f9