### PR TITLE
Impose local OCDB DefaultStorage when snapshot is used

### DIFF
--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -254,6 +254,7 @@ void main_AODtrainRawAndMC(Int_t merge=0, Bool_t isMC=kFALSE, Bool_t refiltering
     else {
       // set OCDB snapshot mode
       AliCDBManager *cdbm = AliCDBManager::Instance();
+      cdbm->SetDefaultStorage("local://");
       cdbm->SetSnapshotMode("OCDBrec.root");
     }
   }else{
@@ -294,7 +295,7 @@ void main_AODtrainRawAndMC(Int_t merge=0, Bool_t isMC=kFALSE, Bool_t refiltering
   }
   
   Bool_t needGrid=kFALSE;
-  if(merge || doCDBconnect) needGrid=kTRUE;
+  if(merge) needGrid=kTRUE;
   if(gSystem->Getenv("OCDB_PATH")) needGrid=kFALSE;
 
   if (needGrid) 

--- a/DataProc/CPass0/main_recCPass0.C
+++ b/DataProc/CPass0/main_recCPass0.C
@@ -103,8 +103,9 @@ void main_recCPass0(const char *filename="raw.root",Int_t nevents=-1, const char
 
   // Upload CDB entries from the snapshot (local root file) if snapshot exist
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    rec.SetDefaultStorage("local://");
-    rec.SetCDBSnapshotMode("OCDB.root");
+    man->SetDefaultStorage("local://");
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
   }
   else {
     // setup ocdb by custom (if any) or default settings

--- a/DataProc/CPass0/main_runCalibTrain.C
+++ b/DataProc/CPass0/main_runCalibTrain.C
@@ -32,11 +32,6 @@ void main_runCalibTrain(Int_t runNumber, const char* inFileName = "AliESDs.root"
   // setting geometry and B-field from GRP
   printf("runNumber from runCalibTrain = %d\n",runNumber);
   printf("ocdb from runCalibTrain = %s\n",ocdb);
-  if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    AliCDBManager::Instance()->SetSnapshotMode("OCDB.root");
-    printf("ocdb from snapshot\n");
-  }
-
   AliSysInfo::AddStamp("BeforeConfiguringCalibTrain");
   ConfigCalibTrain(runNumber, ocdb);
   AliSysInfo::AddStamp("AfterConfiguringCalibTrain");  

--- a/DataProc/CPass0/recCPass0.C
+++ b/DataProc/CPass0/recCPass0.C
@@ -16,10 +16,6 @@ void recCPass0(const char *filename="raw.root",Int_t nevents=-1, const char *ocd
   if (gSystem->AccessPathName("localOCDBaccessConfig.C", kFileExists)==0) {        
     gROOT->LoadMacro("localOCDBaccessConfig.C");
   }
-  else { // default settings
-    AliCDBManager* man = AliCDBManager::Instance();
-    man->SetRaw(kTRUE);
-  }
 
   TString cdbMode = gSystem->Getenv("OCDB_SNAPSHOT_CREATE");
   if (cdbMode == "kTRUE") {

--- a/DataProc/CPass1/main_recCPass1.C
+++ b/DataProc/CPass1/main_recCPass1.C
@@ -81,7 +81,9 @@ void main_recCPass1(const char *filename="raw.root",Int_t nevents=-1, const char
 
   // Upload CDB entries from the snapshot (local root file) if snapshot exist
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    rec.SetCDBSnapshotMode("OCDB.root");
+    man->SetDefaultStorage("local://");
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
   }
   else {
     // setup ocdb by custom (if any) or default settings

--- a/DataProc/CPass1/main_recCPass1_OuterDet.C
+++ b/DataProc/CPass1/main_recCPass1_OuterDet.C
@@ -38,8 +38,9 @@ void main_recCPass1_OuterDet(const char *filename="raw.root",Int_t nevents=-1, c
   AliReconstruction rec;
   // Upload CDB entries from the snapshot (local root file) if snapshot exist
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    //rec.SetFromCDBSnapshot("OCDB.root");
-    rec.SetCDBSnapshotMode("OCDB.root");
+    man->SetDefaultStorage("local://");
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
   }
   if (gSystem->AccessPathName("localOCDBaccessConfig.C", kFileExists)==0) {        
     gInterpreter->ProcessLine("localOCDBaccessConfig();");

--- a/DataProc/CPass1/recCPass1.C
+++ b/DataProc/CPass1/recCPass1.C
@@ -16,10 +16,7 @@ void recCPass1(const char *filename="raw.root",Int_t nevents=-1, const char *ocd
   if (gSystem->AccessPathName("localOCDBaccessConfig.C", kFileExists)==0) {
     gROOT->LoadMacro("localOCDBaccessConfig.C");
   }
-  else { // default settings
-    AliCDBManager* man = AliCDBManager::Instance();
-    man->SetRaw(kTRUE);
-  }
+
   TString cdbMode = gSystem->Getenv("OCDB_SNAPSHOT_CREATE");
   if (cdbMode == "kTRUE") {
     // macro to create the snapshot

--- a/DataProc/Common/ConfigCalibTrain.C
+++ b/DataProc/Common/ConfigCalibTrain.C
@@ -17,16 +17,16 @@ void ConfigCalibTrain(Int_t run, const char *ocdb="raw://"){
   printf("setting run to %d\n",run);
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {  
     Printf("ConfigCalibTrain: using OCDB snapshot");
+    AliCDBManager::Instance()->SetDefaultStorage("local://");
+    AliCDBManager::Instance()->SetRaw(kFALSE);
     AliCDBManager::Instance()->SetSnapshotMode("OCDB.root");
   }
   else {
     Printf("ConfigCalibTrain: NOT using OCDB snapshot");
+    AliCDBManager::Instance()->SetDefaultStorage(ocdb);
   }
-  Printf("Default storage is %s", ocdb);
-
-  AliCDBManager::Instance()->SetDefaultStorage(ocdb);
   AliCDBManager::Instance()->SetRun(run); 
-
+  
   // magnetic field
   if ( !TGeoGlobalMagField::Instance()->GetField() ) {
     printf("Loading field map...\n");

--- a/DataProc/Common/main_runFilteringTask.C
+++ b/DataProc/Common/main_runFilteringTask.C
@@ -43,6 +43,13 @@ void main_runFilteringTask( const char* esdList,
     //handler->SetReadTR(kFALSE);
     mgr->SetMCtruthEventHandler(handlerMC);
 
+    if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {
+      AliCDBManager * man = AliCDBManager::Instance();
+      man->SetDefaultStorage("local://");
+      man->SetRaw(kFALSE);
+      man->SetSnapshotMode("OCDB.root");
+    }
+    
     AddTaskCDBconnect(ocdb);
 
     // Create input chain

--- a/DataProc/Common/raw2clust.C
+++ b/DataProc/Common/raw2clust.C
@@ -14,7 +14,9 @@ void raw2clust(const char *filename="raw.root", Int_t nevents=-1,const char *ocd
   man->SetDefaultStorage(ocdb);
   // Upload CDB entries from the snapshot (local root file) if snapshot exist
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    rec.SetCDBSnapshotMode("OCDB.root");
+    man->SetDefaultStorage("local://");
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
   }
 
   if (gSystem->AccessPathName("localOCDBaccessConfig.C", kFileExists)==0) {        

--- a/DataProc/PPass/main_rec.C
+++ b/DataProc/PPass/main_rec.C
@@ -51,12 +51,14 @@ void main_rec(const char *filename="raw.root", const char* options="")
   }
 
   // Upload CDB entries from the snapshot (local root file) if snapshot exist
+  AliCDBManager* man = AliCDBManager::Instance();
+
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    rec.SetDefaultStorage("local://");
-    rec.SetCDBSnapshotMode("OCDB.root");
+    man->SetDefaultStorage("local://");
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
   }
   else {
-    AliCDBManager* man = AliCDBManager::Instance();
     // setup ocdb by custom (if any) or default settings
     if (gSystem->AccessPathName("OCDBconfig.C", kFileExists)==0) {
       gROOT->ProcessLine("OCDBconfig.C");
@@ -75,6 +77,7 @@ void main_rec(const char *filename="raw.root", const char* options="")
     //
     TString cdbMode = gSystem->Getenv("OCDB_SNAPSHOT_CREATE");
     if (cdbMode == "kTRUE") {
+      if (!man->IsDefaultStorageSet()) man->SetRaw(kTRUE);
       gROOT->ProcessLine(TString::Format("CreateSnapshot(\"OCDB.root\", \"%s\")", filename));
       return;
     }

--- a/DataProc/muon_calo/main_rec.C
+++ b/DataProc/muon_calo/main_rec.C
@@ -10,8 +10,10 @@ void main_rec(const char *filename="raw.root", const char* options="")
 
   // Upload CDB entries from the snapshot (local root file) if snapshot exist
   if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {        
-    rec.SetDefaultStorage("local://");
-    rec.SetCDBSnapshotMode("OCDB.root");
+    AliCDBManager * man = AliCDBManager::Instance();
+    man->SetDefaultStorage("local://");
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
   }
   else {
     // setup ocdb by custom (if any) or default settings
@@ -61,11 +63,6 @@ void main_rec(const char *filename="raw.root", const char* options="")
   if(useFast){
       printf(">>>>> Using fast magnetic field \n");
       AliMagF::SetFastFieldDefault(kTRUE);
-  }
-
-  // Upload CDB entries from the snapshot (local root file) if snapshot exist
-  if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {
-    rec.SetCDBSnapshotMode("OCDB.root");
   }
 
   // switch off cleanESD

--- a/QA/main_QAtrain_duo.C
+++ b/QA/main_QAtrain_duo.C
@@ -147,6 +147,15 @@ void main_QAtrain_duo(const char *suffix="", Int_t run = 0,
   PrintSettings();
 
   TString cdbString(cdb);
+  if (gSystem->AccessPathName("OCDB.root", kFileExists)==0) {
+    AliCDBManager * man = AliCDBManager::Instance();
+    cdbString = "local://";
+    printf("Will use OCDB snaphot, set default storage to local\n");
+    man->SetDefaultStorage(cdbString.Data());
+    man->SetRaw(kFALSE);
+    man->SetSnapshotMode("OCDB.root");
+  }
+
   if (cdbString.Contains("raw://") && !gSystem->Getenv("OCDB_PATH"))
   {
     TGrid::Connect("alien://");


### PR DESCRIPTION
This is to avoid unnecessary queries to alien, which often delay the jobs