### PR TITLE
Do not update MeanVertex in CPass0 also for 18r

### DIFF
--- a/DataProc/CPass0/main_makeOCDB.C
+++ b/DataProc/CPass0/main_makeOCDB.C
@@ -41,6 +41,7 @@ void main_makeOCDB(Int_t runNumber, TString  targetOCDBstorage="", TString sourc
   Bool_t isLHC13c =  LHCperiod.Contains("LHC13c");
   Bool_t isLHC15o =  LHCperiod.Contains("LHC15o");
   Bool_t isLHC18q =  LHCperiod.Contains("LHC18q");
+  Bool_t isLHC18r =  LHCperiod.Contains("LHC18r");
   printf("LHCperiod:%s\n isLHC10:%d isLHC11:%d isLHC12:%d isLHC13:%d isLHC13b:%d isLHC13c:%d\n",LHCperiod.Data(),(Int_t)isLHC10,(Int_t)isLHC11,(Int_t)isLHC12,(Int_t)isLHC13,(Int_t)isLHC13b,(Int_t)isLHC13c);
 
   // Steering Tasks - set output storage
@@ -230,7 +231,7 @@ void main_makeOCDB(Int_t runNumber, TString  targetOCDBstorage="", TString sourc
   
   //Mean Vertex
   AliMeanVertexPreprocessorOffline * procesMeanVtx=0;
-  if (detStr.Contains("ITSSPD") && SPD_qf && !isLHC15o && !isLHC18q) {
+  if (detStr.Contains("ITSSPD") && SPD_qf && !isLHC15o && !isLHC18q && !isLHC18r) {
     Printf("\n******* Calibrating MeanVertex *******");
     procesMeanVtx = new AliMeanVertexPreprocessorOffline;
     procesMeanVtx->ProcessOutput("CalibObjects.root", targetStorage, runNumber);


### PR DESCRIPTION
Hello @afestant , 

I ping you only as I don't know Davide's git account... (If you do, please add him). 
I implemented the check also for 18r, now, for MeanVertex to not be done in CPass0 for this period. 

Cheers,

Chiara