### PR TITLE
New single muons parametrisation for PbPb 5TeV (LHC18r)

### DIFF
--- a/MC/CustomGenerators/PWGDQ/Muon_GenParamSingle_PbPb5TeV_1.C
+++ b/MC/CustomGenerators/PWGDQ/Muon_GenParamSingle_PbPb5TeV_1.C
@@ -2,7 +2,7 @@
 // Parameterized generator for single muons //
 //==========================================//
 // Info about this particular tunning:      //
-// - PbPb@5.02TeV data (LHC15o)             //
+// - PbPb@5.02TeV data (LHC18r)             //
 // - CMSL7 events with physics selection    //
 // - 50-90% centrality class (V0M)          //
 // - Standard muon selection with pDCA      //
@@ -54,12 +54,12 @@ Double_t PtMuon(const Double_t *px, const Double_t */*dummy*/)
 
   Double_t x=*px;
 
-  Double_t p0 = 811.367;
-  Double_t p1 = 0.804372;
-  Double_t p2 = 0.614056;
-  Double_t p3 = 10.4864;
-  Double_t p4 = -0.000650586;
-  Double_t p5 = -1.72877;
+  Double_t p0 = 797.446;
+  Double_t p1 = 0.830278,;
+  Double_t p2 = 0.632177;
+  Double_t p3 = 10.2202;
+  Double_t p4 = -0.000614809;
+  Double_t p5 = -1.70993;
 
   return p0 * (1. / TMath::Power(p1 + TMath::Power(x,p2), p3) + p4 * TMath::Exp(p5*x));
 }
@@ -71,11 +71,11 @@ Double_t YMuon(const Double_t *py, const Double_t */*dummy*/)
 
   Double_t y = *py;
 
-  Double_t p0 = 1.81086;
-  Double_t p1 = 0.;
-  Double_t p2 = -0.0983371;
-  Double_t p3 = 0.;
-  Double_t p4 = 0.00270169;
+  Double_t p0 = 1.87732;
+  Double_t p1 = 0.00658212;
+  Double_t p2 = -0.0988071;
+  Double_t p3 = -0.000452746;
+  Double_t p4 = 0.00269782;
 
   return p0 * (1. + p1*y + p2*y*y + p3*y*y*y + p4*y*y*y*y);
 }


### PR DESCRIPTION
Update of the single muons parametrisation for PbPb at 5 TeV from tunning on LHC18r data