### PR TITLE
auto-disable ADA PMT shielding if year<2017

### DIFF
--- a/MC/DetectorConfig.C
+++ b/MC/DetectorConfig.C
@@ -540,6 +540,7 @@ DetectorInit(Int_t tag)
      if (!isFluka){ // does not work for now with Fluka
         //=================== AD parameters ============================
         AliAD *AD = new AliADv1("AD", "normal AD");
+	if(year<2017) ((AliADv1*) AD)->EnablePmtShieldingADA(kFALSE);
         if( tag == kDetectorPhosOnly)
         AD->DisableStepManager();
      }


### PR DESCRIPTION
Update DetectorInit(...) to automatically disable ADA PMT shielding if the year is less than 2017 as this is the year when the shielding was installed.