### PR TITLE
Decide if create ADA PMT shielding based on year

### DIFF
--- a/MC/DetectorConfig.C
+++ b/MC/DetectorConfig.C
@@ -539,7 +539,11 @@ DetectorInit(Int_t tag)
   if (iAD){
      if (!isFluka){ // does not work for now with Fluka
         //=================== AD parameters ============================
-        AliAD *AD = new AliADv1("AD", "normal AD");
+        
+	// AliAD *AD = new AliADv1("AD", "normal AD");
+        AliAD *AD = NULL;
+        if (year>0) AD = new AliADv1("AD", Form("normal AD year=%d", year));
+        else        AD = new AliADv1("AD", "normal AD");
         if( tag == kDetectorPhosOnly)
         AD->DisableStepManager();
      }


### PR DESCRIPTION
Decide whether to create or not ADA PMT shielding based on the year passed to the title of the ADv1 constructor.
If year<=0, then do not pass that into the title, in which case AD will be constructed with default values (by default AD assumes that it must construct the shielding).