### PR TITLE
Fix after changes in return value of the AddTaskEmcalTriggerQA_QAtrain.C

### DIFF
--- a/QA/main_QAtrain_duo.C
+++ b/QA/main_QAtrain_duo.C
@@ -680,7 +680,7 @@ void AddAnalysisTasks(const char *suffix, const char *cdb_location)
     //AliAnalysisTaskEMCALTriggerQA *emctrig = AddTaskEMCALTriggerQA();
 //     emctrig->GetRecoUtils()->SwitchOffBadChannelsRemoval();
     AliEmcalTriggerMakerTask *emctrigmaker = AddTaskEmcalTriggerMakerNew("EmcalTriggers");
-    AliEmcalTriggerQATask *emctrig = AddTaskEmcalTriggerQA_QAtrain(run_number);
+    AddTaskEmcalTriggerQA_QAtrain(run_number);
   }
   //     
   // FLOW and BF QA (C.Perez && A.Rodriguez)


### PR DESCRIPTION
In AliPhysics v5-09-44b and from v5-09-46, the returned object of
the macro changed. Since we don't use it, we just remove it, to
remain backward compatible without checks on the version of AliPhysics.