### PR TITLE
trigger range 1.6 -> 1.0 in dedicated Lc PbPb generator macro

### DIFF
--- a/MC/CustomGenerators/PWGHF/Hijing_HF001.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_HF001.C
@@ -32,19 +32,19 @@ GeneratorCustom(TString opt = "")
   ((AliGenPythia *)phf)->SetPtHard(pth[ipt], pth[ipt + 1]);
   if(opt.EqualTo(optList[3])) {// Lc --> K0sp
     ((AliGenPythia *)phf)->SetTriggerParticle(4122, 999, 999, -1, 1000);
-    ((AliGenPythia *)phf)->SetTriggerY(1.6);
+    ((AliGenPythia *)phf)->SetTriggerY(1.0);
     ((AliGenPythia *)phf)->SetHeavyQuarkYRange(-1.5,1.5);
     ((AliGenPythia *)phf)->SetForceDecay(AliDecayer::kLcpK0S);  //Force Lc decay mode in PYTHIA to Lc --> K0s+p
   }
   if(opt.EqualTo(optList[4])) {// Lc --> K0sp (modified for BDT signal)
     ((AliGenPythia *)phf)->SetTriggerParticle(4122, 999, 999, -1, 1000);
-    ((AliGenPythia *)phf)->SetTriggerY(1.6);
+    ((AliGenPythia *)phf)->SetTriggerY(1.0);
     ((AliGenPythia *)phf)->SetHeavyQuarkYRange(-1.5,1.5);
     ((AliGenPythia *)phf)->SetForceDecay(AliDecayer::kLcpK0SBDTsig);  //Force Lc decay mode in PYTHIA to Lc --> K0s+p with forced K0->K0S->pi+pi-
   }
   if(opt.EqualTo(optList[5])) {// Lc --> pKpi
     ((AliGenPythia *)phf)->SetTriggerParticle(4122, 999, 999, -1, 1000);
-    ((AliGenPythia *)phf)->SetTriggerY(1.6);
+    ((AliGenPythia *)phf)->SetTriggerY(1.0);
     ((AliGenPythia *)phf)->SetHeavyQuarkYRange(-1.5,1.5);
     ((AliGenPythia *)phf)->SetForceDecay(AliDecayer::kLcpKpi);  //Force Lc decay mode in PYTHIA to Lc->pKpi
   }

--- a/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_Lc.C
+++ b/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_Lc.C
@@ -2,12 +2,12 @@ AliGenerator *GeneratorCustom(TString opt = "")
 
 {
 
-  Decay_t decay[2] = {AliDecayer::kLcpKpi, AliDecayer::kLcpK0S};
-  TString optList[2] = {"LcpKpi","LcpK0S"};
-  TString label[2] = {"LcpKpi PYTHIA","LcpK0S PYTHIA"};
+  Decay_t decay[3] = {AliDecayer::kLcpKpi, AliDecayer::kLcpK0S, AliDecayer::kLcpK0SBDTsig};
+  TString optList[3] = {"LcpKpi","LcpK0S", "LcpK0SBDTsig"};
+  TString label[3] = {"LcpKpi PYTHIA","LcpK0S PYTHIA", "LcpK0S PYTHIA (forced K decay)"};
 
   Int_t idecay = 0;  
-  for (Int_t iopt = 0; iopt < 2; iopt++ ) {
+  for (Int_t iopt = 0; iopt < 3; iopt++ ) {
       if (opt.EqualTo(optList[iopt])) idecay = iopt;
   }
 


### PR DESCRIPTION
Changes trigger range for Lc from 1.6 to 1.0 in PbPb generator macro for dedicated Lc productions, as discussed in PB slides. (see https://alice.its.cern.ch/jira/browse/ALIROOT-8208) 

Also adds "forced" K0 decay channel to Pythia generator for Lc in pp.