### PR TITLE
Use HLT TPC-compression-only mode by default

### DIFF
--- a/MC/SimulationConfig.C
+++ b/MC/SimulationConfig.C
@@ -17,6 +17,8 @@
 #include "TROOT.h"
 #endif
 
+#include "../Utils/CheckAliRootVersion.C"
+
 enum ESimulation_t {
   kSimulationDefault,
   kSimulationMuon,
@@ -230,6 +232,7 @@ void SimulationDefault(AliSimulation &sim)
   //
   // HLT settings
   TString hltConfig = "auto";
+  if (IsAliPhysicsMoreRecentThanOrEqualTo("v5-09-46")) hltConfig = "auto chains=TPC-compression-only";
   if (gSystem->Getenv("CONFIG_HLT"))
     hltConfig = gSystem->Getenv("CONFIG_HLT");
   sim.SetRunHLT(hltConfig.Data());


### PR DESCRIPTION
This needs current AliRoot master, i.e. commits b52ecaa4477312144a9611dffb47057ebc659e77 and b52ecaa4477312144a9611dffb47057ebc659e77.

It changes the HLT behavior such by default only the TPC compression runs, which should speed up MC simulation. We should double-check that this has no side effects.