### PR TITLE
fix typo

### DIFF
--- a/MC/CustomGenerators/PWGDQ/Muon_GenParamSingle_PbPb5TeV_1.C
+++ b/MC/CustomGenerators/PWGDQ/Muon_GenParamSingle_PbPb5TeV_1.C
@@ -55,7 +55,7 @@ Double_t PtMuon(const Double_t *px, const Double_t */*dummy*/)
   Double_t x=*px;
 
   Double_t p0 = 797.446;
-  Double_t p1 = 0.830278,;
+  Double_t p1 = 0.830278;
   Double_t p2 = 0.632177;
   Double_t p3 = 10.2202;
   Double_t p4 = -0.000614809;


### PR DESCRIPTION
Hi @miweberSMI ,

I am going to open a new prod request to simulate single muons with the new PbPb tuning for tracking efficiency systematic studies. Unfortunately we will need a new tag because of this typo... :-( Is there a new tag already foreseen in the next days? If not, may I ask one?

Cheers,
Philippe
