### PR TITLE
MC update for ALIDPG_ROOT when running with tar ball, relevant only f…

### DIFF
--- a/bin/aliroot_dpgsim.sh
+++ b/bin/aliroot_dpgsim.sh
@@ -8,7 +8,7 @@ if [ "$ALIDPG_ROOT" = "" ]; then
 
 	echo "Using AliDPG from tarball"
 	tar zxvf alidpg.tgz
-	export ALIDPG_ROOT=AliDPG
+	export ALIDPG_ROOT=`pwd`/AliDPG
 	
     else
 	


### PR DESCRIPTION
…or embedding

Ciao @chiarazampolli, @fprino 

Here is the update to make ALIDPG_ROOT as absolute path - relevant only for MC embedding productions and only when running with AliDPG tar ball.

Thanks!

Yours,
Catalin.