### PR TITLE
update macros for PbPb 2018 MC simulations

### DIFF
--- a/MC/CustomGenerators/PWGDQ/GenJPsiParaSet.C
+++ b/MC/CustomGenerators/PWGDQ/GenJPsiParaSet.C
@@ -1,0 +1,93 @@
+/**********************************************************************
+ Created on : 21/05/2019
+ Purpose    : paraset for prompt JPsi
+**********************************************************************/
+
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "TRandom.h"
+#include "AliGenParam.h"
+#endif 
+
+//           generator functions
+//
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+Double_t  V2Zero_M( const Double_t* /*px*/, const Double_t */*dummy*/ )
+{
+
+  return 0.0;
+
+}
+ 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------
+Int_t IpJpsi_M(TRandom *)
+{
+  // J/Psi composition
+  return 443;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+Double_t PtJpsiPbPb5020_0020(const Double_t *px, const Double_t *dummy)
+{
+  // J/Psi pT
+  // PbPb 5.02 TeV, 0-20 %
+  //
+  const Double_t kC    = 4.28158e-02;
+  const Double_t kpt0  = 4.87205e+00;
+  const Double_t kn    = 5.84596e+00;
+
+  Double_t pt          = px[0];
+  
+  return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+}
+
+Double_t PtJpsiPbPb5020_2040(const Double_t *px, const Double_t *dummy)
+{
+  // J/Psi pT
+  // PbPb 5.02 TeV, 20-40 %
+  //
+  const Double_t kC    = 1.43606e-02;
+  const Double_t kpt0  = 3.20879e+00;
+  const Double_t kn    = 3.22259e+00;
+  Double_t pt          = px[0];
+
+  return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+}
+
+Double_t PtJpsiPbPb5020_4090(const Double_t *px, const Double_t *dummy)
+{
+  // J/Psi pT
+  // PbPb 5.02 TeV, 40-90 %
+  //
+  const Double_t kC    = 1.61589e-03;
+  const Double_t kpt0  = 3.39896e+00;
+  const Double_t kn    = 3.04499e+00;
+  Double_t pt          = px[0];
+  
+  return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+}
+
+Double_t YJpsiFlat( const Double_t */*x*/, const Double_t */*dummy*/ )
+{
+  return 1.;
+}
+//---------------------------------------------------------------------
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//           generators
+//
+AliGenParam* GenJPsiParaSet(TString option)
+{
+  printf("\nProcessing config setup : JPsiParaSet \n\n");
+  printf("Parameter option %s ",option.Data());
+
+  
+  AliGenParam *genJpsi = 0x0;
+  if(option == "UserParam_PbPb5TeV_minbias")    genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_0020, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  else if(option == "UserParam_PbPb5TeV_0020")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_0020, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  else if(option == "UserParam_PbPb5TeV_2040")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_2040, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  else if(option == "UserParam_PbPb5TeV_4090")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_4090, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  return genJpsi;
+}

--- a/MC/CustomGenerators/PWGDQ/Hijing_Jpsiee002.C
+++ b/MC/CustomGenerators/PWGDQ/Hijing_Jpsiee002.C
@@ -1,0 +1,29 @@
+AliGenerator *
+GeneratorCustom()
+{
+  TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
+    
+  AliGenCocktail *ctl = GeneratorCocktail("Hijing_Jpsiee002");
+
+  if(!simulation.Contains("Embed")){
+    AliGenerator *hij = GeneratorHijing();
+    ctl->AddGenerator(hij, "Hijing", 1.);
+  }
+
+  // centrality dependent injection
+  TFormula *formula = new TFormula("Signals","(x<14.0)*(11.0-0.4*x-0.02*x*x) + (x>14.0)*2.0"); 
+
+  if (uidConfig % 10 < 7) {
+    AliGenerator *jpsi  = Generator_Jpsiee("UserParam_PbPb5TeV_0020", 1.0, 0.0, 0.0, 0.0);
+    ctl->AddGenerator(jpsi, "Jpsi2ee", 1., formula);
+    TFile *file = new TFile("typeHF_4.proc", "recreate");
+    file->Close();
+  }
+  else {
+    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0);
+    ctl->AddGenerator(bjpsi, "B2Jpsi2ee", 1., formula);
+    TFile *file = new TFile("typeHF_5.proc", "recreate");
+    file->Close();
+  }
+  return ctl;
+}

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -1529,7 +1529,13 @@ Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_
   gener->UsePerEventRates();
   //
   // J/psi
-  AliGenParam *jpsi = new AliGenParam(1, AliGenMUONlib::kJpsi, params, "Jpsi");
+  TString stringParams = params;
+  if(stringParams.Contains("UserParam")){ 
+   // use private parametrization for y / pT instead of AliGenMUONlib
+   gROOT->LoadMacro("$ALIDPG_ROOT/MC/CustomGenerators/PWGDQ/GenJPsiParaSet.C++");
+   jpsi = GenJPsiParaSet(stringParams);
+  }
+  else jpsi = new AliGenParam(1, AliGenMUONlib::kJpsi, params, "Jpsi");
   jpsi->SetPtRange(0., 1000.);
   jpsi->SetYRange(-1.0, 1.0);
   jpsi->SetPhiRange(0., 360.);


### PR DESCRIPTION
The commit includes:
1) custom generator macro for PbPb 2018 (Hijing_Jpsiee002.C ) with centrality dependent injection (thanks to Ionut for the suggestion)
2) GenJPsiParaSet.C to set up user pT / y parametrizations (thanks to Markus for providing pT shapes from PbPb 2015)
3) small change in GeneratorConfig.C in order to use the functions at point 2)