### PR TITLE
[WIP] Use old-style TIter syntax

### DIFF
--- a/QA/main_QAtrain_duo.C
+++ b/QA/main_QAtrain_duo.C
@@ -682,10 +682,9 @@ void AddAnalysisTasks(const char *suffix, const char *cdb_location)
     AliEmcalTriggerMakerTask *emctrigmaker = AddTaskEmcalTriggerMakerNew("EmcalTriggers");
     emctrigmaker->SetUseBuiltinEventSelection(true);
     TObjArray triggerqatasks = AddTaskEmcalTriggerQA_QAtrain(run_number);
-    for(TIter &taskiter = TIter(&triggerqatasks).Begin(); taskiter != TIter::End(); ++taskiter) {
-      AliEmcalTriggerQATask *triggerqatask = static_cast<AliEmcalTriggerQATask *>(taskiter());
-      triggerqatask->SetUseBuiltinEventSelection(true);
-    }
+    TIter taskiter(&triggerqatasks);
+    AliEmcalTriggerQATask *triggerqatask(0x0);
+    while((triggerqatask = dynamic_cast<AliEmcalTriggerQATask *>(taskiter.Next()))) triggerqatask->SetUseBuiltinEventSelection(true);
   }
   //     
   // FLOW and BF QA (C.Perez && A.Rodriguez)


### PR DESCRIPTION
C++-iterator-style syntax of TIter was not ignoring
null entries in TObjArray under ROOT5, leading to
a segfault due to access of nullptr.