### PR TITLE
Merge gen.headers in RemoveBKGFromGalice

### DIFF
--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -1047,13 +1047,13 @@ if [[ $CONFIG_MODE == *"extractembedded"* ]] && [[ $CONFIG_SIMULATION == *"Embed
 	mv "AliESDfriends.root" "AliESDfriends_ORIG.root"
 	mv "AliESDfriends_EMB.root" "AliESDfriends.root"
 	## Removed for proper handling of AliMultSelection task
-	#mv "galice.root" "galice_ORIG.root"
-	#mv "galice_EMB.root" "galice.root"
+	mv "galice.root" "galice_ORIG.root"
+	mv "galice_EMB.root" "galice.root"
     else
 	mv "AliESDs_EMB.root" "AliESDs.root"
 	mv "AliESDfriends_EMB.root" "AliESDfriends.root"
-       	## Removed for proper handling of AliMultSelection task
-	#mv "galice_EMB.root" "galice.root"
+       	# Removed for proper handling of AliMultSelection task
+	mv "galice_EMB.root" "galice.root"
     fi
 fi
     


### PR DESCRIPTION
Hi @miweberSMI @chiarazampolli 
This PR merges the gen.headers of the BG event to that of the embedded one, rewriting the TE tree in the galice.root (written to galice_EMB.root) of the latter when RemoveBKGFromGalice is called.

Note, now the RemoveBKGFromGalice is called automatically from the ExtractEmbedded() with {{keepMixed==false}}.

The steering script will need to save  galice_EMB.root as galice.root, as it is done for AliESDs.