### PR TITLE
[ALIROOT-8339] MC production for J/psi jets in pp at 13 TeV (LHC16, 17, 18)

### DIFF
--- a/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
+++ b/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
@@ -2,7 +2,7 @@ AliGenerator *
 GeneratorCustom()
 {
   AliGenCocktail *ctl   = GeneratorCocktail("Pythia6_Perugia2011_Jpsiee001");
-  AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
+  AliGenerator   *pyt   = GeneratorPythia6Jets(kPythia6Tune_Perugia2011);
   ctl->AddGenerator(pyt,  "Pythia6", 1.);
   if (uidConfig % 10 < 7) {
     AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0, 0.0);

--- a/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
+++ b/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
@@ -2,7 +2,7 @@ AliGenerator *
 GeneratorCustom()
 {
   AliGenCocktail *ctl   = GeneratorCocktail("Pythia6_Perugia2011_Jpsiee001");
-  AliGenerator   *pyt   = GeneratorPythia6Jets(kPythia6Tune_Perugia2011);
+  AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
   ctl->AddGenerator(pyt,  "Pythia6", 1.);
   if (uidConfig % 10 < 7) {
     AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0);

--- a/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
+++ b/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
@@ -5,13 +5,13 @@ GeneratorCustom()
   AliGenerator   *pyt   = GeneratorPythia6Jets(kPythia6Tune_Perugia2011);
   ctl->AddGenerator(pyt,  "Pythia6", 1.);
   if (uidConfig % 10 < 7) {
-    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0, 0.0);
+    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0);
     ctl->AddGenerator(jpsi, "Jpsi2ee", 1., NULL, 2);
     TFile *file = new TFile("typeHF_4.proc", "recreate");
     file->Close();
   }
   else {
-    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0, 0.0);
+    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0);
     ctl->AddGenerator(bjpsi, "B2Jpsi2ee", 1.);
     TFile *file = new TFile("typeHF_5.proc", "recreate");
     file->Close();

--- a/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
+++ b/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV.C
@@ -5,13 +5,13 @@ GeneratorCustom()
   AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
   ctl->AddGenerator(pyt,  "Pythia6", 1.);
   if (uidConfig % 10 < 7) {
-    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0);
+    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0, 0.0);
     ctl->AddGenerator(jpsi, "Jpsi2ee", 1., NULL, 2);
     TFile *file = new TFile("typeHF_4.proc", "recreate");
     file->Close();
   }
   else {
-    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0);
+    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0, 0.0);
     ctl->AddGenerator(bjpsi, "B2Jpsi2ee", 1.);
     TFile *file = new TFile("typeHF_5.proc", "recreate");
     file->Close();

--- a/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV_HighPt.C
+++ b/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV_HighPt.C
@@ -1,0 +1,20 @@
+AliGenerator *
+GeneratorCustom()
+{
+  AliGenCocktail *ctl   = GeneratorCocktail("Pythia6_Perugia2011_Jpsiee001");
+  AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
+  ctl->AddGenerator(pyt,  "Pythia6", 1.);
+  if (uidConfig % 10 < 5) {
+    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0, 0.0);
+    ctl->AddGenerator(jpsi, "Jpsi2ee", 1., NULL, 2);
+    TFile *file = new TFile("typeHF_4.proc", "recreate");
+    file->Close();
+  }
+  else {
+    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 0.3, 0.7);
+    ctl->AddGenerator(bjpsi, "B2Jpsi2ee", 1.);
+    TFile *file = new TFile("typeHF_5.proc", "recreate");
+    file->Close();
+  }
+  return ctl;
+}

--- a/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV_HighPt.C
+++ b/MC/CustomGenerators/PWGDQ/Pythia6_Perugia2011_Jpsi2ee13TeV_HighPt.C
@@ -2,16 +2,16 @@ AliGenerator *
 GeneratorCustom()
 {
   AliGenCocktail *ctl   = GeneratorCocktail("Pythia6_Perugia2011_Jpsiee001");
-  AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
+  AliGenerator   *pyt   = GeneratorPythia6Jets(kPythia6Tune_Perugia2011);
   ctl->AddGenerator(pyt,  "Pythia6", 1.);
   if (uidConfig % 10 < 5) {
-    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0, 0.0);
+    AliGenerator *jpsi  = Generator_Jpsiee("pp 5.03", 0.7, 0.0, 0.3, 0.0);
     ctl->AddGenerator(jpsi, "Jpsi2ee", 1., NULL, 2);
     TFile *file = new TFile("typeHF_4.proc", "recreate");
     file->Close();
   }
   else {
-    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 0.3, 0.7);
+    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 0.3, kFALSE, 0.7);
     ctl->AddGenerator(bjpsi, "B2Jpsi2ee", 1.);
     TFile *file = new TFile("typeHF_5.proc", "recreate");
     file->Close();

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -198,7 +198,7 @@ AliGenerator *GeneratorPythia8GammaJet(Int_t tune = 0, Int_t acceptance = kCalor
 AliGenerator *GeneratorPhojet();
 AliGenerator *GeneratorEPOSLHC();
 AliGenerator *GeneratorHijing();
-AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Float_t bhighfrac, Bool_t useEvtGenForB=kFALSE);
+AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Float_t bhighfrac = 0.0, Bool_t useEvtGenForB=kFALSE);
 AliGenerator *Generator_Nuclex(UInt_t injbit, Bool_t antiparticle, Int_t ninj, Float_t max_pt = 10.f, Float_t max_y = 1.);
 AliGenerator *GeneratorStarlight();
 AliGenerator *GeneratorDRgen();
@@ -1590,14 +1590,12 @@ Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_
   pythiaHighPt->SetEnergyCMS(energyConfig);
   pythiaHighPt->SetTune(kPythia6Tune_Perugia0);
   pythiaHighPt->UseNewMultipleInteractionsScenario();
-  if(useEvtGenForB) pythiaHighPt->SetForceDecay(kNoDecayBeauty);
-  else {
+    // Cuts on child - J/psi
   pythiaHighPt->SetCutOnChild(1);
   pythiaHighPt->SetPdgCodeParticleforAcceptanceCut(443);
   pythiaHighPt->SetChildYRange(-1, 1);
   pythiaHighPt->SetChildPtRange(9, 50.);
   pythiaHighPt->SetForceDecay(kBJpsiUndecayed);
-  }
   pythiaHighPt->SetStackFillOpt(AliGenPythia::kHeavyFlavor);
   //
   // 

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -198,7 +198,7 @@ AliGenerator *GeneratorPythia8GammaJet(Int_t tune = 0, Int_t acceptance = kCalor
 AliGenerator *GeneratorPhojet();
 AliGenerator *GeneratorEPOSLHC();
 AliGenerator *GeneratorHijing();
-AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Float_t bhighfrac = 0.0, Bool_t useEvtGenForB=kFALSE);
+AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Bool_t useEvtGenForB=kFALSE, Float_t bhighfrac = 0.0);
 AliGenerator *Generator_Nuclex(UInt_t injbit, Bool_t antiparticle, Int_t ninj, Float_t max_pt = 10.f, Float_t max_y = 1.);
 AliGenerator *GeneratorStarlight();
 AliGenerator *GeneratorDRgen();
@@ -1498,7 +1498,7 @@ AliGenParam* GeneratorParam(int n, int pdg, double ptmin, double ptmax, double y
 /*** JPSI -> EE ****************************************************/
 
 AliGenerator *
-Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Float_t bhighfrac, Bool_t useEvtGenForB)
+Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Bool_t useEvtGenForB, Float_t bhighfrac)
 {
 
   /*

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -198,7 +198,7 @@ AliGenerator *GeneratorPythia8GammaJet(Int_t tune = 0, Int_t acceptance = kCalor
 AliGenerator *GeneratorPhojet();
 AliGenerator *GeneratorEPOSLHC();
 AliGenerator *GeneratorHijing();
-AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Bool_t useEvtGenForB=kFALSE);
+AliGenerator *Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Float_t bhighfrac, Bool_t useEvtGenForB=kFALSE);
 AliGenerator *Generator_Nuclex(UInt_t injbit, Bool_t antiparticle, Int_t ninj, Float_t max_pt = 10.f, Float_t max_y = 1.);
 AliGenerator *GeneratorStarlight();
 AliGenerator *GeneratorDRgen();
@@ -1498,7 +1498,7 @@ AliGenParam* GeneratorParam(int n, int pdg, double ptmin, double ptmax, double y
 /*** JPSI -> EE ****************************************************/
 
 AliGenerator *
-Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Bool_t useEvtGenForB)
+Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_t highfrac, Float_t bfrac, Float_t bhighfrac, Bool_t useEvtGenForB)
 {
 
   /*
@@ -1580,6 +1580,25 @@ Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_
   pythia->SetForceDecay(kBJpsiUndecayed);
   }
   pythia->SetStackFillOpt(AliGenPythia::kHeavyFlavor);
+  // Jpsi from B - high pT
+  AliGenPythia *pythiaHighPt = new AliGenPythia(-1);
+  pythiaHighPt->SetMomentumRange(0, 999999.);
+  pythiaHighPt->SetThetaRange(0., 180.);
+  pythiaHighPt->SetYRange(-2., 2.);
+  pythiaHighPt->SetPtRange(0, 1000.);
+  pythiaHighPt->SetProcess(kPyBeautyppMNRwmi);
+  pythiaHighPt->SetEnergyCMS(energyConfig);
+  pythiaHighPt->SetTune(kPythia6Tune_Perugia0);
+  pythiaHighPt->UseNewMultipleInteractionsScenario();
+  if(useEvtGenForB) pythiaHighPt->SetForceDecay(kNoDecayBeauty);
+  else {
+  pythiaHighPt->SetCutOnChild(1);
+  pythiaHighPt->SetPdgCodeParticleforAcceptanceCut(443);
+  pythiaHighPt->SetChildYRange(-1, 1);
+  pythiaHighPt->SetChildPtRange(9, 50.);
+  pythiaHighPt->SetForceDecay(kBJpsiUndecayed);
+  }
+  pythiaHighPt->SetStackFillOpt(AliGenPythia::kHeavyFlavor);
   //
   // 
   AliGenEvtGen *gene = new AliGenEvtGen();
@@ -1591,6 +1610,7 @@ Generator_Jpsiee(const Char_t *params, Float_t jpsifrac, Float_t lowfrac, Float_
   if (lowfrac  > 0.) gener->AddGenerator(jpsiLowPt,      "jpsiLowPt",      lowfrac);
   if (highfrac > 0.) gener->AddGenerator(jpsiHighPtFlat, "jpsiHighPtFlat", highfrac);
   if (bfrac    > 0.) gener->AddGenerator(pythia,         "Pythia",         bfrac);
+  if (bhighfrac    > 0.) gener->AddGenerator(pythiaHighPt,         "jpsiBdecayPythiaHighPt",         bhighfrac);
   gener->AddGenerator(gene, "EvtGen", 1.);
   //
   return gener;


### PR DESCRIPTION
For J/psi in jets analysis, we reconstruct high pT J/psi  by using EMCal triggered events. Typical energy threshold for EMCal is 9 GeV for EG1/DG1 and 4 GeV for EG2/DG2. Corresponding pT cuts for J/psi is 10 and 5 .

Furthermore, the MC samples with non-prompt J/psi in similiar pT region is required for efficiency, corrections and detector response matrix.

In this pull request, some changes was committed to make the enhancement of non-prompt J/psi in high pT region:
* NEW argument <bhighfrac> for Generator_Jpsiee in MC/GeneratorConfig.C
* Create the generator for BJpsi2ee with pT>9 and |Y|<1 cuts of child. (Copied from existed generator)
* NEW macro for cutomized fractions, like ()

The fractions should be further discussed. Your are welcome for the reviews and comments.