### PR TITLE
Redo V0s before the gamma conversion task in AOD filtering

### DIFF
--- a/AOD/AODtrainRawAndMC.C
+++ b/AOD/AODtrainRawAndMC.C
@@ -18,6 +18,7 @@ void AODtrainRawAndMC(Int_t merge=0, Bool_t isMC=kFALSE, Bool_t refilteringMode=
   gROOT->LoadMacro("$ALICE_ROOT/ANALYSIS/ESDfilter/macros/AddTaskESDFilter.C");
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGHF/vertexingHF/macros/AddTaskVertexingHF.C");
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGDQ/dielectron/macros/AddTaskJPSIFilter.C");
+  gROOT->LoadMacro("$ALICE_PHYSICS/PWGLF/STRANGENESS/Cascades/Run2/macros/AddTaskWeakDecayVertexer.C");
   /*
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGJE/macros/AddTaskJets.C");
   gROOT->LoadMacro("$ALICE_PHYSICS/PWGJE/macros/AddTaskJetCluster.C");

--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -525,6 +525,24 @@ void AddAnalysisTasks(const char *cdb_location, Bool_t isMC)
     AddTaskCentralMult(useMC);
   }
 
+  // redo V0s
+  AliAnalysisTaskWeakDecayVertexer *taskWDV = AddTaskWeakDecayVertexer();
+  taskWDV -> SetUseImprovedFinding();
+  //V0-Related topological selections
+  taskWDV -> SetV0VertexerDCAFirstToPV(0.05);
+  taskWDV -> SetV0VertexerDCASecondtoPV(0.05);
+  taskWDV -> SetV0VertexerDCAV0Daughters(1.50);
+  taskWDV -> SetV0VertexerCosinePA(0.95);
+  taskWDV -> SetV0VertexerMinRadius(0.9);
+  taskWDV -> SetV0VertexerMaxRadius(200);
+  //Cascade-Related topological selections
+  taskWDV -> SetCascVertexerMinV0ImpactParameter(0.05);
+  taskWDV -> SetCascVertexerV0MassWindow(0.008);
+  taskWDV -> SetCascVertexerDCABachToPV(0.05);
+  taskWDV -> SetCascVertexerDCACascadeDaughters(2.0);
+  taskWDV -> SetCascVertexerCascadeMinRadius(.5);
+  taskWDV -> SetCascVertexerCascadeCosinePA(.95);
+
   //PWGAgammaconv
   if (iPWGGAgammaconv) {
     Int_t dataset=iCollision;

--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -526,7 +526,7 @@ void AddAnalysisTasks(const char *cdb_location, Bool_t isMC)
   }
 
   // redo V0s in case of pp (for now; PbPb needs to be tested)
-  if ( iCollision == kpp) { 
+  if (iCollision == kpp || iCollision == kpPb || iCollision == kPbp) { 
     AliAnalysisTaskWeakDecayVertexer *taskWDV = AddTaskWeakDecayVertexer();
     taskWDV -> SetUseImprovedFinding();
     //V0-Related topological selections

--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -525,24 +525,26 @@ void AddAnalysisTasks(const char *cdb_location, Bool_t isMC)
     AddTaskCentralMult(useMC);
   }
 
-  // redo V0s
-  AliAnalysisTaskWeakDecayVertexer *taskWDV = AddTaskWeakDecayVertexer();
-  taskWDV -> SetUseImprovedFinding();
-  //V0-Related topological selections
-  taskWDV -> SetV0VertexerDCAFirstToPV(0.05);
-  taskWDV -> SetV0VertexerDCASecondtoPV(0.05);
-  taskWDV -> SetV0VertexerDCAV0Daughters(1.50);
-  taskWDV -> SetV0VertexerCosinePA(0.95);
-  taskWDV -> SetV0VertexerMinRadius(0.9);
-  taskWDV -> SetV0VertexerMaxRadius(200);
-  //Cascade-Related topological selections
-  taskWDV -> SetCascVertexerMinV0ImpactParameter(0.05);
-  taskWDV -> SetCascVertexerV0MassWindow(0.008);
-  taskWDV -> SetCascVertexerDCABachToPV(0.05);
-  taskWDV -> SetCascVertexerDCACascadeDaughters(2.0);
-  taskWDV -> SetCascVertexerCascadeMinRadius(.5);
-  taskWDV -> SetCascVertexerCascadeCosinePA(.95);
-
+  // redo V0s in case of pp (for now; PbPb needs to be tested)
+  if ( iCollision == kpp) { 
+    AliAnalysisTaskWeakDecayVertexer *taskWDV = AddTaskWeakDecayVertexer();
+    taskWDV -> SetUseImprovedFinding();
+    //V0-Related topological selections
+    taskWDV -> SetV0VertexerDCAFirstToPV(0.05);
+    taskWDV -> SetV0VertexerDCASecondtoPV(0.05);
+    taskWDV -> SetV0VertexerDCAV0Daughters(1.50);
+    taskWDV -> SetV0VertexerCosinePA(0.95);
+    taskWDV -> SetV0VertexerMinRadius(0.9);
+    taskWDV -> SetV0VertexerMaxRadius(200);
+    //Cascade-Related topological selections
+    taskWDV -> SetCascVertexerMinV0ImpactParameter(0.05);
+    taskWDV -> SetCascVertexerV0MassWindow(0.008);
+    taskWDV -> SetCascVertexerDCABachToPV(0.05);
+    taskWDV -> SetCascVertexerDCACascadeDaughters(2.0);
+    taskWDV -> SetCascVertexerCascadeMinRadius(.5);
+    taskWDV -> SetCascVertexerCascadeCosinePA(.95);
+  }
+  
   //PWGAgammaconv
   if (iPWGGAgammaconv) {
     Int_t dataset=iCollision;


### PR DESCRIPTION
Dear @catalinristea , @fprino , 

This is the change to have the V0 redone at filtering time, which we discussed to have as default. Can you check that everything is fine?

Pinging also @ddobrigk and @shahor02 , for information. 

@ddobrigk , the settings are those that you mentioned in https://alice.its.cern.ch/jira/browse/ALIROOT-8272?focusedCommentId=235244&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-235244

Chiara