### PR TITLE
Optionally activate fine binning in Y/X and Z/X

### DIFF
--- a/DataProc/TPCSPCalibration/procResidData.C
+++ b/DataProc/TPCSPCalibration/procResidData.C
@@ -105,7 +105,7 @@ AliTPCDcalibRes*  CreateSetCalib(int run,int tmin,int tmax,const char* inp)
   AliTPCDcalibRes* clbn = new AliTPCDcalibRes(run);
   clbn->SetTMinMax(tmin,tmax);
   clbn->SetResidualList(inp);
-  //
+  // 
   TString envs;
 
   // detectors to use >>>>>>>>>>>>>>>>
@@ -138,11 +138,23 @@ AliTPCDcalibRes*  CreateSetCalib(int run,int tmin,int tmax,const char* inp)
     ::Info("CreateResCalib","SetNZ2XBins %s",envs.Data());
     clbn->SetNZ2XBins(envs.Atoi());
   }
+  else if (envs=="fineZ2X") {
+    float z2x[]={0., 0.1, 0.2, 0.3,  0.4,0.6,0.8,1.};
+    int nz = sizeof(z2x)/sizeof(float)-1;
+    ::Info("CreateResCalib","SetNZ2XBins %s : %d bins",envs.Data(), nz);
+    clbn->SetZ2XBinning(nz,z2x);
+  } 
   //
   envs = gSystem->Getenv("distNBinsY");;
   if (envs.IsDigit()) {
     ::Info("CreateResCalib","SetNY2XBins %s",envs.Data());
     clbn->SetNY2XBins(envs.Atoi());
+  }
+  else if (envs=="fineY2X") {
+    float y2x[]={-1.000000,-0.933333,-0.866667,-0.800000,-0.733333,-0.600000,-0.466667,-0.333333,-0.200000,-0.066667,+0.066667,+0.200000,+0.333333,+0.466667,+0.600000,+0.733333, 0.800000, +0.866667,0.933333, +1.000000};
+    int ny = sizeof(y2x)/sizeof(float)-1;
+    ::Info("CreateResCalib","SetNY2XBins %s : %d bins",envs.Data(), ny);
+    clbn->SetY2XBinning(ny,y2x);
   }
   //
   // binning <<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
If distNBinsY or distNBinsZ env.vars are equal to "fineY2X" or "fineZ2X" respectively, then for the corresponding dimension the fine binning hardcoded in y2x or z2x arrays will be used.

These options can be activated by setting in the ``spacePointCalibrationDefineTimeBinsvDrift.jdl``
````
DISTNBINSY = "fineY2X";
DISTNBINSZ = "fineZ2X";
````
Note: processing with fine binning is better to be done with longer time intervals, for the 3-runs-test I used distTimeBin=2400 instead of  distTimeBin=1200 (used for LHC18q/r)
