### PR TITLE
Fix: remove redundant error check

### DIFF
--- a/DataProc/CPass0/runCPass0.sh
+++ b/DataProc/CPass0/runCPass0.sh
@@ -392,9 +392,4 @@ fi
 
 echo "The time spent in aliroot sessions is $timeUsed"
 
-if [ $exitcode -ne 0 ]; then
-    echo "runCalibTrain.C exited with code $exitcode" > validation_error.message
-    exit 40
-fi
-
 exit 0


### PR DESCRIPTION
runCPass0.sh had in the end extra check for , attributing it to runCalibTrain while the value
was set by the checkResTree.C for legitimate reason (no events in the ESD) not considered to be critical