### PR TITLE
Disable AliTPCcalibTime merging by very tight cut on stat.

### DIFF
--- a/DataProc/MergeOutputs/mergeByComponent.C
+++ b/DataProc/MergeOutputs/mergeByComponent.C
@@ -56,7 +56,7 @@ void MergeCPass(const Char_t *list, TString component, TString outputFileName)
   //AliTPCcalibGainMult::SetMergeEntriesCut(2000000);
   //AliTPCcalibAlign::SetMergeEntriesCut(10000000);
   //AliTPCcalibTracks::SetMergeEntriesCut(10000000);
-  //AliTPCcalibTime::SetResHistoMergeCut(10000000);
+  AliTPCcalibTime::SetResHistoMergeCut(1000);
 
    AliTPCcalibTimeGain::SetMergeEntriesCut(500000);
    AliTPCcalibGainMult::SetMergeEntriesCut(500000);


### PR DESCRIPTION
In my local tests this fixes the memory overrun.