### PR TITLE
update generation macros for MC Pb-Pb 2018 (pass2)

### DIFF
--- a/MC/CustomGenerators/PWGDQ/GenJPsiParaSet.C
+++ b/MC/CustomGenerators/PWGDQ/GenJPsiParaSet.C
@@ -43,6 +43,22 @@ Double_t PtJpsiPbPb5020_0020(const Double_t *px, const Double_t *dummy)
   return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+Double_t PtJpsiPbPb5020_0010(const Double_t *px, const Double_t *dummy)
+{
+  // J/Psi pT
+  // PbPb 5.02 TeV, 0-10 % (2018)
+  //
+  const Double_t kC    = 4.93446e-02;
+  const Double_t kpt0  = 3.19847e+00;
+  const Double_t kn    = 3.33812e+00;
+
+  Double_t pt          = px[0];
+
+  return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+}
+
+
 Double_t PtJpsiPbPb5020_2040(const Double_t *px, const Double_t *dummy)
 {
   // J/Psi pT
@@ -55,6 +71,22 @@ Double_t PtJpsiPbPb5020_2040(const Double_t *px, const Double_t *dummy)
 
   return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+Double_t PtJpsiPbPb5020_3050(const Double_t *px, const Double_t *dummy)
+{
+  // J/Psi pT
+  // PbPb 5.02 TeV, 0-10 % (2018)
+  //
+  const Double_t kC    = 5.06325e-03;
+  const Double_t kpt0  = 3.22806e+00;
+  const Double_t kn    = 2.95146e+00;
+
+  Double_t pt          = px[0];
+
+  return kC * pt /TMath::Power((1. + (pt/kpt0)*(pt/kpt0)),kn);
+}
+
 
 Double_t PtJpsiPbPb5020_4090(const Double_t *px, const Double_t *dummy)
 {
@@ -85,9 +117,11 @@ AliGenParam* GenJPsiParaSet(TString option)
 
   
   AliGenParam *genJpsi = 0x0;
-  if(option == "UserParam_PbPb5TeV_minbias")    genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_0020, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  if(option == "UserParam_PbPb5TeV_minbias")    genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_0010, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  else if(option == "UserParam_PbPb5TeV_0010")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_0010, YJpsiFlat, V2Zero_M, IpJpsi_M);
   else if(option == "UserParam_PbPb5TeV_0020")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_0020, YJpsiFlat, V2Zero_M, IpJpsi_M);
   else if(option == "UserParam_PbPb5TeV_2040")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_2040, YJpsiFlat, V2Zero_M, IpJpsi_M);
+  else if(option == "UserParam_PbPb5TeV_3050")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_3050, YJpsiFlat, V2Zero_M, IpJpsi_M);
   else if(option == "UserParam_PbPb5TeV_4090")  genJpsi = new AliGenParam(1,-1, PtJpsiPbPb5020_4090, YJpsiFlat, V2Zero_M, IpJpsi_M);
   return genJpsi;
 }

--- a/MC/CustomGenerators/PWGDQ/Hijing_Jpsiee002.C
+++ b/MC/CustomGenerators/PWGDQ/Hijing_Jpsiee002.C
@@ -1,5 +1,5 @@
 AliGenerator *
-GeneratorCustom()
+GeneratorCustom(TString ptParamPrompt="UserParam_PbPb5TeV_0010")
 {
   TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
     
@@ -14,13 +14,13 @@ GeneratorCustom()
   TFormula *formula = new TFormula("Signals","(x<14.0)*(11.0-0.4*x-0.02*x*x) + (x>14.0)*2.0"); 
 
   if (uidConfig % 10 < 7) {
-    AliGenerator *jpsi  = Generator_Jpsiee("UserParam_PbPb5TeV_0020", 1.0, 0.0, 0.0, 0.0);
+    AliGenerator *jpsi  = Generator_Jpsiee(ptParamPrompt, 1.0, 0.0, 0.0, 0.0); 
     ctl->AddGenerator(jpsi, "Jpsi2ee", 1., formula);
     TFile *file = new TFile("typeHF_4.proc", "recreate");
     file->Close();
   }
   else {
-    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0);
+    AliGenerator *bjpsi = Generator_Jpsiee("Pythia BBar", 0.0, 0.0, 0.0, 1.0, kTRUE /*useEvtGenForBdecays*/);
     ctl->AddGenerator(bjpsi, "B2Jpsi2ee", 1., formula);
     TFile *file = new TFile("typeHF_5.proc", "recreate");
     file->Close();


### PR DESCRIPTION
Changes include: 
- update of prompt jpsi pt-spectra (from Pb-Pb 2018 data)
- EvtGen usage for B->J/psi+X decays  