### PR TITLE
Commented out printf for bcm mask in DPG:Hijing_pileup generator, whi…

### DIFF
--- a/MC/CustomGenerators/DPG/Hijing_Pileup.C
+++ b/MC/CustomGenerators/DPG/Hijing_Pileup.C
@@ -41,7 +41,7 @@ AliGenerator *GeneratorCustom(){
   bcm.ReplaceAll("L","H");
   bcm.ReplaceAll("X","L");
   
-  printf("   BC mask = %s\n",bcm.Data());
+  //printf("   BC mask = %s\n",bcm.Data());
   printf("   mu = %f\n",mu);
   printf("   Energy = %f\n",energyConfig);
   


### PR DESCRIPTION
…ch exhausted 2048 chars when read from OCDB