### PR TITLE
fixes for Root6

### DIFF
--- a/MC/ReconstructionConfig.C
+++ b/MC/ReconstructionConfig.C
@@ -13,6 +13,10 @@
 #include "AliMagF.h"
 #endif
 
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "AliESDV0Params.h"
+#endif
+
 enum EReconstruction_t {
   kReconstructionDefault,
   kReconstructionMuon,
@@ -207,9 +211,8 @@ void ReconstructionConfig(AliReconstruction &rec, int tag_tmp)
 
   case kReconstructionForNuclei:
     ReconstructionDefault(rec);
-    const char* conf = gSystem->Getenv("ALIEN_JDL_CONFIG_HE3_PION_THRESHOLD");
-    if (conf) {
-      int threshold = atoi(conf);
+    if (gSystem->Getenv("ALIEN_JDL_CONFIG_HE3_PION_THRESHOLD")) {
+      int threshold = atoi(gSystem->Getenv("ALIEN_JDL_CONFIG_HE3_PION_THRESHOLD"));
       threshold = threshold ? threshold : 130;
       rec.SetPIDforTrackingOptimisedForNuclei(threshold);
     }


### PR DESCRIPTION
2 fixes:

- The introduction of line 
itsRecoParam->GetESDV0Params()->SetMaxPidProbPionForb(0.9); 
needs the include of AliESDV0Params

- redeclaration of "const conf" variable on switch. Avoid declaration.