### PR TITLE
add casting to AliGenCocktail for Root6

### DIFF
--- a/MC/CustomGenerators/DPG/PerformanceGenerator.C
+++ b/MC/CustomGenerators/DPG/PerformanceGenerator.C
@@ -5,7 +5,7 @@
 void  AddNuclei(AliGenCocktail *ctl);
 
 AliGenerator * GeneratorCustom() {
-  AliGenCocktail *ctl    = GeneratorCocktail("Hijing+Generator for performance (tracking,PID) studies");
+  AliGenCocktail *ctl    = (AliGenCocktail*) GeneratorCocktail("Hijing+Generator for performance (tracking,PID) studies");
   AliGenerator   *hij    = GeneratorHijing();
   AliGenerator   *genJet = PerformanceGenerator();
   ctl->AddGenerator(hij,    "Hijing", 1.);

--- a/MC/CustomGenerators/DPG/SingleParticleGun001.C
+++ b/MC/CustomGenerators/DPG/SingleParticleGun001.C
@@ -1,7 +1,7 @@
 AliGenerator *GeneratorCustom(TString opt = "")
 {
 
-  AliGenCocktail *ctl  = GeneratorCocktail("SingleParticleGun001");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("SingleParticleGun001");
   
   Printf("INFO: Particle with PDG = %d will be injected in %2.1f < pT < %2.1f (GeV/c), %2.1f < y < %2.1f, %2.1f < phi < %2.1f \n",pdgConfig,ptminConfig,ptmaxConfig,yminConfig,ymaxConfig,phiminConfig,phimaxConfig);
 

--- a/MC/CustomGenerators/DPG/Validation_pp001.C
+++ b/MC/CustomGenerators/DPG/Validation_pp001.C
@@ -2,7 +2,7 @@ AliGenerator *
 GeneratorCustom()
 {
   //
-  AliGenCocktail *ctl = GeneratorCocktail("GEANT4_validation");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("GEANT4_validation");
   //
   // Pythia8 Monash 2013
   AliGenerator   *py8 = GeneratorPythia8(kPythia8Tune_Monash2013);

--- a/MC/CustomGenerators/PWGHF/EPOS_HFbjetpPb.C
+++ b/MC/CustomGenerators/PWGHF/EPOS_HFbjetpPb.C
@@ -5,7 +5,7 @@ GeneratorCustom(TString opt = "")
   // set the xmldoc path using PYTHIA8DATA enviroement var
   gSystem->Setenv("PYTHIA8DATA", gSystem->ExpandPathName("$ALICE_ROOT/PYTHIA8/pythia8/xmldoc"));  
   
-  AliGenCocktail *ctl  = GeneratorCocktail("EPOS_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("EPOS_HF");
   Float_t randHF = gRandom->Rndm();
   if(randHF>0.176797){ // add EPOS generator for p-Pb
     AliGenerator *epos = GeneratorEPOSLHC();

--- a/MC/CustomGenerators/PWGHF/HIJING_HFbjetpPb.C
+++ b/MC/CustomGenerators/PWGHF/HIJING_HFbjetpPb.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom(TString opt = "")
 {
-  AliGenCocktail *ctl  = GeneratorCocktail("HIJING_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("HIJING_HF");
   Float_t randHF = gRandom->Rndm();
   if(randHF>0.176797){ // add HIJING generator for p-Pb
     AliGenerator *hij = GeneratorHijing();

--- a/MC/CustomGenerators/PWGHF/Hijing_HF001.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_HF001.C
@@ -1,6 +1,6 @@
 AliGenerator *GeneratorCustom(TString opt = "")
 {
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_HF");
 
   TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
   Int_t ntimes=1;

--- a/MC/CustomGenerators/PWGHF/Hijing_HF002.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_HF002.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom(TString opt = "")
 {
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_HF");
   Float_t randHF = gRandom->Rndm();
   if(randHF>0.176797){
     AliGenerator   *hij  = GeneratorHijing();

--- a/MC/CustomGenerators/PWGHF/Hijing_HFjetPbPb.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_HFjetPbPb.C
@@ -2,7 +2,7 @@ AliGenerator *
 GeneratorCustom(TString opt = "")
 {
 	
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_HF");
   TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
 
   if(!simulation.Contains("Embed")){

--- a/MC/CustomGenerators/PWGHF/Hijing_Pythia8_Monash2013_HF001.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_Pythia8_Monash2013_HF001.C
@@ -7,7 +7,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
     if (opt.EqualTo(optList[iopt]))
       channelOption = iopt;
 
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Pythia8_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Pythia8_HF");
 
   TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
   Int_t ntimes=1;

--- a/MC/CustomGenerators/PWGHF/Hijing_Xe_HF.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_Xe_HF.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom(TString opt = "")
 {
-    AliGenCocktail *ctl  = GeneratorCocktail("Hijing_HF");
+    AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_HF");
   
         AliGenerator   *hij  = GeneratorHijing();
         ctl->AddGenerator(hij, "Hijing", 1.);

--- a/MC/CustomGenerators/PWGHF/Hijing_Xe_HF_Omegaccc_bkg.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_Xe_HF_Omegaccc_bkg.C
@@ -4,7 +4,7 @@ GeneratorCustom(TString opt = "")
 
     AliPDG::AddParticlesToPdgDataBase();
 
-    AliGenCocktail *ctl  = GeneratorCocktail("Hijing_HF");
+    AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_HF");
   
         AliGenerator   *hij  = GeneratorHijing();
         ctl->AddGenerator(hij, "Hijing", 1.);

--- a/MC/CustomGenerators/PWGHF/Hijing_pPb_Lc.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_pPb_Lc.C
@@ -9,7 +9,7 @@ AliGenerator * GeneratorCustom(TString opt = "")
     if (opt.EqualTo(optList[iopt])) idecay = iopt;
   }
 
-  AliGenCocktail *ctl = GeneratorCocktail("Hijing_Lc");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Hijing_Lc");
 
   Float_t randHF = gRandom->Rndm();
   if (randHF>0.176797){ // add Hijing for p-Pb

--- a/MC/CustomGenerators/PWGHF/PYTHIA_HFjetpp.C
+++ b/MC/CustomGenerators/PWGHF/PYTHIA_HFjetpp.C
@@ -4,7 +4,7 @@ GeneratorCustom(TString opt = "")
     // set the xmldoc path using PYTHIA8DATA enviroement var
     gSystem->Setenv("PYTHIA8DATA", gSystem->ExpandPathName("$ALICE_ROOT/PYTHIA8/pythia8/xmldoc"));
 
-    AliGenCocktail *ctl  = GeneratorCocktail("PYTHIA_HF");
+    AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("PYTHIA_HF");
     
     Int_t process[2] = {kPythia6HeavyProcess_Charm, kPythia6HeavyProcess_Beauty};
     Int_t decay[5]   = {kPythia6HeavyDecay_Hadrons, kPythia6HeavyDecay_HadronsWithV0, kPythia6HeavyDecay_Electron, kPythia6HeavyDecay_All, kPythia6HeavyDecay_All_bDecaysEvtGen};

--- a/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_D2Hdedicated.C
+++ b/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_D2Hdedicated.C
@@ -24,7 +24,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
        if (opt.EqualTo(optList[imult][iopt])) { multOption = imult;  channelOption = iopt;}
      }
   }
-//  AliGenCocktail *ctl = GeneratorCocktail("Perugia2011_HF");
+//  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Perugia2011_HF");
   AliGenPythia* pyth = GeneratorPythia6(kPythia6Tune_Perugia2011);
   pyth->SetProcess(iprocess);
   pyth->SetTriggerParticle(sign * triggerParticle[channelOption],999,999,-1,1000); //Lc or Ds, etamin, etamax, ptmin, ptmax

--- a/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_HF001_HighMult.C
+++ b/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_HF001_HighMult.C
@@ -16,7 +16,7 @@ GeneratorCustom(TString opt = "")
     if (opt.Contains(optList[iopt]))
       idecay = iopt;
   //
-  AliGenCocktail *ctl  = GeneratorCocktail("Perugia2011_HF");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Perugia2011_HF");
   //
   AliGenerator *phf  = GeneratorPythia6Heavy(process[iprocess], decay[idecay], kPythia6Tune_Perugia2011, kFALSE);
   

--- a/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_Lc.C
+++ b/MC/CustomGenerators/PWGHF/Pythia6_Perugia2011_Lc.C
@@ -11,7 +11,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
       if (opt.EqualTo(optList[iopt])) idecay = iopt;
   }
 
-//  AliGenCocktail *ctl = GeneratorCocktail("Perugia2011_HF");
+//  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Perugia2011_HF");
   AliGenPythia* pyth = GeneratorPythia6(kPythia6Tune_Perugia2011);
   pyth->SetProcess(kPyCharmppMNRwmi);
   pyth->SetTriggerParticle(4122,999,999,-1,1000); //Lc, etamin, etamax, ptmin, ptmax

--- a/MC/CustomGenerators/PWGLF/Box_Nuclex001.C
+++ b/MC/CustomGenerators/PWGLF/Box_Nuclex001.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Box_Nuclex001");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Box_Nuclex001");
 
   const Int_t pdgcodes[5] = {
     2212,

--- a/MC/CustomGenerators/PWGLF/Box_Nuclex002.C
+++ b/MC/CustomGenerators/PWGLF/Box_Nuclex002.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-    AliGenCocktail *ctl = GeneratorCocktail("Box_Nuclex002");
+    AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Box_Nuclex002");
 
     const Int_t pdgcode = 1010010030;
     const Char_t *name = "Hypertriton";

--- a/MC/CustomGenerators/PWGLF/Dpmjet_Rsn_pPb001.C
+++ b/MC/CustomGenerators/PWGLF/Dpmjet_Rsn_pPb001.C
@@ -32,7 +32,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
   else return kFALSE;
 
 
-  AliGenCocktail *ctl  = GeneratorCocktail("DPMJET_RsnInject");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("DPMJET_RsnInject");
   AliGenDPMjet *dpmjet  = (AliGenDPMjet*) GeneratorPhojet();
   ctl->AddGenerator(dpmjet,"Dpmjet",           1.);
 

--- a/MC/CustomGenerators/PWGLF/Dpmjet_Rsn_pPb002.C
+++ b/MC/CustomGenerators/PWGLF/Dpmjet_Rsn_pPb002.C
@@ -15,7 +15,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
   Double_t y_L = -0.6;
   Double_t y_H = 0.1;
 
-  AliGenCocktail *ctl  = GeneratorCocktail("DPMJET_RsnInject");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("DPMJET_RsnInject");
   AliGenDPMjet *dpmjet  = (AliGenDPMjet*) GeneratorPhojet();
   ctl->AddGenerator(dpmjet,"Dpmjet",           1.);
 

--- a/MC/CustomGenerators/PWGLF/EPOS_StrInj_pPb8.C
+++ b/MC/CustomGenerators/PWGLF/EPOS_StrInj_pPb8.C
@@ -5,7 +5,7 @@ AliGenerator *GeneratorCustom(){
   
   Int_t sign = uidConfig % 2 == 0 ? 1 : -1;
   
-  AliGenCocktail *ctl  = GeneratorCocktail("EPOS_StrInj_pPb8");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("EPOS_StrInj_pPb8");
   AliGenerator   *epos  = GeneratorEPOSLHC();
   
   AliGenerator   *ixi = GeneratorInjector(ninjxi, sign * 3312, 2., 20., -1.2, 1.2);

--- a/MC/CustomGenerators/PWGLF/Epos_Nuclex001.C
+++ b/MC/CustomGenerators/PWGLF/Epos_Nuclex001.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Epos_Nuclex001");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Epos_Nuclex001");
   AliGenerator   *epos  = GeneratorEPOSLHC();
   ctl->AddGenerator(epos, "EPOSLHC", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0xF, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Epos_Nuclex005.C
+++ b/MC/CustomGenerators/PWGLF/Epos_Nuclex005.C
@@ -2,7 +2,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Epos_Nuclex005");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Epos_Nuclex005");
   AliGenerator   *epos  = GeneratorEPOSLHC();
   ctl->AddGenerator(epos, "EPOSLHC", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0x70000, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Hijing_Exo.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Exo.C
@@ -1,6 +1,6 @@
 AliGenerator * GeneratorCustom()
 {
-  AliGenerator   *gen = GeneratorCocktail("LambdaN");
+  AliGenerator   *gen = (AliGenCocktail*) GeneratorCocktail("LambdaN");
 
   AliGenCocktail *ctl = (AliGenCocktail*) gen; 
   

--- a/MC/CustomGenerators/PWGLF/Hijing_Lnn.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Lnn.C
@@ -1,6 +1,6 @@
 AliGenerator * GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Hijing_Nuclex001");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Hijing_Nuclex001");
   AliGenerator   *hij   = GeneratorHijing();
   ctl->AddGenerator(hij,  "Hijing", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0x2000, kFALSE, 5,10,1);

--- a/MC/CustomGenerators/PWGLF/Hijing_Nuclex001.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Nuclex001.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Hijing_Nuclex001");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Hijing_Nuclex001");
   AliGenerator   *hij   = GeneratorHijing();
   ctl->AddGenerator(hij,  "Hijing", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0xF, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Hijing_Nuclex003.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Nuclex003.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Hijing_Nuclex003");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Hijing_Nuclex003");
   AliGenerator   *hij   = GeneratorHijing();
   ctl->AddGenerator(hij,  "Hijing", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0xF, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Hijing_Nuclex004.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Nuclex004.C
@@ -4,7 +4,7 @@ GeneratorCustom()
 
   TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
 
-  AliGenCocktail *ctl = GeneratorCocktail("Hijing_Nuclex004");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Hijing_Nuclex004");
 
   if(!simulation.Contains("Embed")){
     AliGenerator *hij = GeneratorHijing();

--- a/MC/CustomGenerators/PWGLF/Hijing_Nuclex005.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Nuclex005.C
@@ -2,7 +2,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Hijing_Nuclex005");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Hijing_Nuclex005");
   AliGenerator   *hij   = GeneratorHijing();
   ctl->AddGenerator(hij,  "Hijing", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0x70000, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Hijing_Rsn001.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Rsn001.C
@@ -14,7 +14,7 @@ GeneratorCustom(TString opt = "")
   Int_t pdg1 = pdglist1[uidConfig % 2]; // select according to unique ID
   Int_t pdg2 = pdglist2[uidConfig % 2]; // select according to unique ID
 
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Rsn002");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Rsn002");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *inj1 = GeneratorInjector(ninj, pdg1, 0., 10., -0.6, 0.6);
   AliGenerator   *inj2 = GeneratorInjector(ninj, pdg2, 0., 10., -0.6, 0.6);

--- a/MC/CustomGenerators/PWGLF/Hijing_Rsn002.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Rsn002.C
@@ -7,7 +7,7 @@ GeneratorCustom(TString opt)
   for (Int_t iopt = 0; iopt < 3; iopt++)
     if (opt.EqualTo(optList[iopt]))
       ninj = ninjlist[iopt];
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Rsn002");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Rsn002");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *inj1 = GeneratorInjector(ninj,  3124, 0., 10., -0.6, 0.6);
   AliGenerator   *inj2 = GeneratorInjector(ninj, -3124, 0., 10., -0.6, 0.6);

--- a/MC/CustomGenerators/PWGLF/Hijing_Rsn003.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Rsn003.C
@@ -20,7 +20,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
 
   AliDecayerPythia *dec = new AliDecayerPythia;
 
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Rsn003");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Rsn003");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *inj1 = GeneratorParam(ninj,  333, 0., pTmax, -0.6, 0.6, dec);
   AliGenerator   *inj2 = GeneratorParam(ninj,  313, 0., pTmax, -0.6, 0.6, dec);

--- a/MC/CustomGenerators/PWGLF/Hijing_Rsn004.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Rsn004.C
@@ -28,7 +28,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
 
   AliDecayerPythia *dec = new AliDecayerPythia;
 
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Rsn004");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Rsn004");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *inj1 = GeneratorParam(ninj,  pdg1, 0., pTmax, -0.6, 0.6, dec);
   AliGenerator   *inj2 = GeneratorParam(ninj,  pdg2, 0., pTmax, -0.6, 0.6, dec);

--- a/MC/CustomGenerators/PWGLF/Hijing_Rsn005.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Rsn005.C
@@ -30,7 +30,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
 
   AliDecayerPythia *dec = new AliDecayerPythia;
 
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Rsn005");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Rsn005");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *inj1 = GeneratorParam(ninj,  pdg1, 0., pTmax, -0.6, 0.6, dec);
   AliGenerator   *inj2 = GeneratorParam(ninj,  pdg2, 0., pTmax, -0.6, 0.6, dec);

--- a/MC/CustomGenerators/PWGLF/Hijing_Str001.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Str001.C
@@ -11,7 +11,7 @@ GeneratorCustom(TString opt)
     if (opt.EqualTo(optList[iopt]))
       iinj = iopt;
   Int_t sign = uidConfig % 2 == 0 ? 1 : -1;
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Str001");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Str001");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *ik0 = GeneratorInjector(ninjk0[iinj],         310, 0., 20., -0.7, 0.7);
   AliGenerator   *ila = GeneratorInjector(ninjla[iinj], sign * 3122, 0., 20., -0.7, 0.7);

--- a/MC/CustomGenerators/PWGLF/Hijing_Str002.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Str002.C
@@ -11,7 +11,7 @@ GeneratorCustom(TString opt)
     if (opt.EqualTo(optList[iopt]))
       iinj = iopt;
   Int_t sign = uidConfig % 2 == 0 ? 1 : -1;
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Str002");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Str002");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *ik0 = GeneratorInjector(ninjk0[iinj],         310, 0., 5., -0.7, 0.7);
   AliGenerator   *ila = GeneratorInjector(ninjla[iinj], sign * 3122, 0., 5., -0.7, 0.7);

--- a/MC/CustomGenerators/PWGLF/Hijing_Str003.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Str003.C
@@ -13,7 +13,7 @@ GeneratorCustom(TString opt = "d")
         if (opt.EqualTo(optList[iopt]))
             iinj = iopt;
     Int_t sign = uidConfig % 2 == 0 ? 1 : -1;
-    AliGenCocktail *ctl  = GeneratorCocktail("Hijing_Str003");
+    AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_Str003");
     AliGenerator   *hij  = GeneratorHijing();
     AliGenerator   *ik0 = GeneratorInjector(ninjk0[iinj],         310, 0., 3., -0.7, 0.7);
     AliGenerator   *ila = GeneratorInjector(ninjla[iinj], sign * 3122, 0., 3., -0.7, 0.7);

--- a/MC/CustomGenerators/PWGLF/Hijing_XeXe_Nuclei.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_XeXe_Nuclei.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_XeXe_Nuclei");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_XeXe_Nuclei");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *iom  = GeneratorInjector(1, 3334, 0.5, 7., -0.7, 0.7);
   AliGenerator   *iaom = GeneratorInjector(1, -3334, 0.5, 7., -0.7, 0.7);

--- a/MC/CustomGenerators/PWGLF/Hijing_XeXe_Omega.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_XeXe_Omega.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_XeXe_Omega");
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_XeXe_Omega");
   AliGenerator   *hij  = GeneratorHijing();
   AliGenerator   *iom  = GeneratorInjector(1, 3334, 0.5, 7., -0.7, 0.7);
   AliGenerator   *iaom = GeneratorInjector(1, -3334, 0.5, 7., -0.7, 0.7);

--- a/MC/CustomGenerators/PWGLF/Pythia6_Perugia2011_Nuclex001.C
+++ b/MC/CustomGenerators/PWGLF/Pythia6_Perugia2011_Nuclex001.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-    AliGenCocktail *ctl   = GeneratorCocktail("Perugia2011_Nuclex001");
+    AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Perugia2011_Nuclex001");
     AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
     ctl->AddGenerator(pyt,  "Pythia6", 1.);
     AliGenerator   *nu1a  = Generator_Nuclex(0xF, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Pythia6_Perugia2011_Nuclex002.C
+++ b/MC/CustomGenerators/PWGLF/Pythia6_Perugia2011_Nuclex002.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom() 
 {
-  AliGenCocktail *ctl   = GeneratorCocktail("Perugia2011_Nuclex002");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Perugia2011_Nuclex002");
   AliGenerator   *pyt   = GeneratorPythia6(kPythia6Tune_Perugia2011);
   ctl->AddGenerator(pyt,  "Pythia6", 1.);
   AliGenerator   *nu1a  = Generator_Nuclex(0x1F, kFALSE, 10);

--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Nuclex001.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Nuclex001.C
@@ -9,7 +9,7 @@ struct particle_inj {
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl = GeneratorCocktail("Monash2013_Nucl001");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Monash2013_Nucl001");
 
   // pythia8
   AliGenerator   *py8 = GeneratorPythia8(kPythia8Tune_Monash2013);

--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn001.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn001.C
@@ -1,7 +1,7 @@
 AliGenerator *
 GeneratorCustom()
 {
-  AliGenCocktail *ctl = GeneratorCocktail("Monash2013_Rsn001");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Monash2013_Rsn001");
   // pythia8
   AliGenerator   *py8 = GeneratorPythia8(kPythia8Tune_Monash2013);
   ctl->AddGenerator(py8, "Pythia8 (Monash2013)", 1.);

--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn002.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn002.C
@@ -8,7 +8,7 @@ struct particle_inj {
 
 AliGenerator* GeneratorCustom()
 {
-  AliGenCocktail *ctl = GeneratorCocktail("Monash2013_RsnNcl002");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Monash2013_RsnNcl002");
   // pythia8
   AliGenerator   *py8 = GeneratorPythia8(kPythia8Tune_Monash2013);
   ctl->AddGenerator(py8, "Pythia8 (Monash2013)", 1.);

--- a/MC/CustomGenerators/PWGLF/Pythia8_StrInj_pp5_2017.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_StrInj_pp5_2017.C
@@ -2,7 +2,7 @@ AliGenerator *GeneratorCustom(){
 
   Int_t sign = uidConfig % 2 == 0 ? 1 : -1;
   
-  AliGenCocktail *ctl = GeneratorCocktail("Pythia8_StrInj_pp5_2017");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Pythia8_StrInj_pp5_2017");
   
   AliGenerator   *py8  = GeneratorPythia8(kPythia8Tune_Monash2013);
   AliGenerator   *ila  = GeneratorInjector(1, sign * 3122, 0.0, 8.0, -0.7, 0.7);

--- a/MC/CustomGenerators/PWGUD/Dpmjet_Starlight.C
+++ b/MC/CustomGenerators/PWGUD/Dpmjet_Starlight.C
@@ -2,7 +2,7 @@ AliGenerator *
 GeneratorCustom()
 {
   // Init cocktail
-  AliGenCocktail* cocktail = GeneratorCocktail("Dpmjet_Starlight");
+  AliGenCocktail* cocktail = (AliGenCocktail*) GeneratorCocktail("Dpmjet_Starlight");
 
   // DPMjet
   AliGenerator   *dpm   = GeneratorPhojet();

--- a/MC/CustomGenerators/Upgrade/Hijing_HFjetUpgradePbPb.C
+++ b/MC/CustomGenerators/Upgrade/Hijing_HFjetUpgradePbPb.C
@@ -2,7 +2,7 @@ AliGenerator *
 GeneratorCustom(TString opt = "")
 {
 	
-  AliGenCocktail *ctl  = GeneratorCocktail("Hijing_HF");  
+  AliGenCocktail *ctl  = (AliGenCocktail*) GeneratorCocktail("Hijing_HF");  
   AliGenerator   *hij  = GeneratorHijing();
   ctl->AddGenerator(hij, "Hijing", 1.);
 

--- a/MC/CustomGenerators/Upgrade/Hijing_QED.C
+++ b/MC/CustomGenerators/Upgrade/Hijing_QED.C
@@ -4,7 +4,7 @@ GeneratorCustom(TString opt = "")
 
   //-----------------------------------------------
   // Cocktail
-  AliGenCocktail *ctl = GeneratorCocktail("Run3_Generators_HIJING_with_QED");
+  AliGenCocktail *ctl = (AliGenCocktail*) GeneratorCocktail("Run3_Generators_HIJING_with_QED");
 
   //-----------------------------------------------
   // HIJING

--- a/MC/CustomGenerators/Upgrade/Hijing_QED_Nuclex01.C
+++ b/MC/CustomGenerators/Upgrade/Hijing_QED_Nuclex01.C
@@ -10,7 +10,7 @@ AliGenerator * GeneratorCustom(TString opt = "")
   
   //-----------------------------------------------
   // Cocktail
-  AliGenCocktail *ctl   = GeneratorCocktail("Run3_Hijing_with_QED_Nuclex001");
+  AliGenCocktail *ctl   = (AliGenCocktail*) GeneratorCocktail("Run3_Hijing_with_QED_Nuclex001");
 
   //-----------------------------------------------
   // HIJING


### PR DESCRIPTION
I think I have spotted all the macros with the root6 casting problem in the CustomGenerator directory and applied this simple fix, not tested but given the tests on the PWGDQ and PWGGA macros, it should be ok