### PR TITLE
Swapping order in which we add trigger and pileup event.

### DIFF
--- a/MC/CustomGenerators/DPG/Dpmjet_Pileup.C
+++ b/MC/CustomGenerators/DPG/Dpmjet_Pileup.C
@@ -26,7 +26,6 @@ AliGenerator *GeneratorCustom(){
   // this is the DPMJET generator for the trigger event,
   // which could contain an impact parameter cut
   AliGenerator   *dpm   = GeneratorPhojet();
-  ctl->AddGenerator(dpm,  "Dpmjet", 1.);
   
   AliGenPileup *genpil = new AliGenPileup();
   // this is the DPMJET generator for the pileup events,
@@ -42,6 +41,7 @@ AliGenerator *GeneratorCustom(){
   genpil->Print();
   
   ctl->AddGenerator(genpil,    "Pileup", 1.);
+  ctl->AddGenerator(dpm,  "Dpmjet", 1.);
   
   return ctl;
 

--- a/MC/CustomGenerators/DPG/EPOS_Pileup.C
+++ b/MC/CustomGenerators/DPG/EPOS_Pileup.C
@@ -26,7 +26,6 @@ AliGenerator *GeneratorCustom(){
   // this is the EPOS generator for the trigger event,
   // which could contain an impact parameter cut
   AliGenerator   *epos   = GeneratorEPOSLHC();
-  ctl->AddGenerator(epos,  "EPOS-LHC", 1.);
   
   AliGenPileup *genpil = new AliGenPileup();
   // this is the EPOS-LHC generator for the pileup events,
@@ -42,6 +41,7 @@ AliGenerator *GeneratorCustom(){
   genpil->Print();
   
   ctl->AddGenerator(genpil,    "Pileup", 1.);
+  ctl->AddGenerator(epos,  "EPOS-LHC", 1.);
   
   return ctl;
 

--- a/MC/CustomGenerators/DPG/Hijing_Pileup_Cent.C
+++ b/MC/CustomGenerators/DPG/Hijing_Pileup_Cent.C
@@ -26,7 +26,6 @@ AliGenerator *GeneratorCustom(){
   // this is the Hijing generator for the trigger event,
   // which could contain an impact parameter cut
   AliGenHijing *hijingC = (AliGenHijing*)GeneratorHijing();
-  ctl->AddGenerator(hijingC,   "Hijing", 1.);
   
   AliGenPileup *genpil = new AliGenPileup();
   // this is the Hijing generator for the pileup events,
@@ -42,6 +41,7 @@ AliGenerator *GeneratorCustom(){
   genpil->Print();
   
   ctl->AddGenerator(genpil,    "Pileup", 1.);
+  ctl->AddGenerator(hijingC,   "Hijing", 1.);
   
   return ctl;
 

--- a/MC/CustomGenerators/PWGLF/Hijing_Nuclex004_pileup.C
+++ b/MC/CustomGenerators/PWGLF/Hijing_Nuclex004_pileup.C
@@ -23,12 +23,24 @@ AliGenerator *GeneratorCustom(){
   // in terms of event rate per bunch crossing
   AliGenCocktail *ctl = (AliGenCocktail*)GeneratorCocktail("Hijing_Nuclex004_PileUp");
 
+  AliGenerator   *nu1a  = Generator_Nuclex(0xF, kFALSE, 10);
+  AliGenerator   *nu1b  = Generator_Nuclex(0xF, kTRUE, 10);
+  AliGenerator   *nu2a  = Generator_Nuclex(0x10, kFALSE, 40);
+  AliGenerator   *nu2b  = Generator_Nuclex(0x10, kTRUE, 40);
+  AliGenerator   *nu3a  = Generator_Nuclex(0xC000, kFALSE, 20);
+  AliGenerator   *nu3b  = Generator_Nuclex(0xC000, kTRUE, 20);
+  ctl->AddGenerator(nu1a,  "Nuclex1a", 1.);
+  ctl->AddGenerator(nu1b,  "Nuclex1b", 1.);
+  ctl->AddGenerator(nu2a,  "Nuclex2a", 1.);
+  ctl->AddGenerator(nu2b,  "Nuclex2b", 1.);
+  ctl->AddGenerator(nu3a,  "Nuclex3a", 1.);
+  ctl->AddGenerator(nu3b,  "Nuclex3b", 1.);
+
   // this is the Hijing generator for the trigger event,
   // which could contain an impact parameter cut
   TString simulation = gSystem->Getenv("CONFIG_SIMULATION");
   if(!simulation.Contains("Embed")){
     AliGenHijing *hijingC = (AliGenHijing*)GeneratorHijing();
-    ctl->AddGenerator(hijingC,   "Hijing", 1.);
     
     AliGenPileup *genpil = new AliGenPileup();
     // this is the Hijing generator for the pileup events,
@@ -44,20 +56,9 @@ AliGenerator *GeneratorCustom(){
     genpil->Print();
     
     ctl->AddGenerator(genpil,    "Pileup", 1.);
+    ctl->AddGenerator(hijingC,   "Hijing", 1.);
   }
 
-  AliGenerator   *nu1a  = Generator_Nuclex(0xF, kFALSE, 10);
-  AliGenerator   *nu1b  = Generator_Nuclex(0xF, kTRUE, 10);
-  AliGenerator   *nu2a  = Generator_Nuclex(0x10, kFALSE, 40);
-  AliGenerator   *nu2b  = Generator_Nuclex(0x10, kTRUE, 40);
-  AliGenerator   *nu3a  = Generator_Nuclex(0xC000, kFALSE, 20);
-  AliGenerator   *nu3b  = Generator_Nuclex(0xC000, kTRUE, 20);
-  ctl->AddGenerator(nu1a,  "Nuclex1a", 1.);
-  ctl->AddGenerator(nu1b,  "Nuclex1b", 1.);
-  ctl->AddGenerator(nu2a,  "Nuclex2a", 1.);
-  ctl->AddGenerator(nu2b,  "Nuclex2b", 1.);
-  ctl->AddGenerator(nu3a,  "Nuclex3a", 1.);
-  ctl->AddGenerator(nu3b,  "Nuclex3b", 1.);
   return ctl;
 
 }


### PR DESCRIPTION
Otherwise the wrong time is associated to the particles,
in case we use AliRoot that do not include
https://github.com/alisw/AliRoot/pull/1189

Also for EPOS and DPMJET and PWGLF:Hijing_Nuclex004_PileUp

See ALIROOT-8502