### PR TITLE
Add maximum lifetime (previously default 1.e-15)

### DIFF
--- a/MC/CustomGenerators/PWGHF/Hijing_Pythia8_Monash2013_HF001.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_Pythia8_Monash2013_HF001.C
@@ -49,6 +49,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
   AliGenPythiaPlus* pyth = (AliGenPythiaPlus*)GeneratorPythia8(kPythia8Tune_Monash2013);
   pyth->SetProcess(process[iprocess]);
   pyth->SetHeavyQuarkYRange(-1.5, 1.5);
+  pyth->SetMaximumLifetime(0.7);
   if(channelOption >= 1) {
     pyth->SetTriggerParticle(sign * triggerPart, 999);
   }


### PR DESCRIPTION
Enlarge maximum lifetime limit from 1.e-15 to 0.7 to keep HF hadrons, which otherwise are removed from the kine tree with kPyCharm and kPyBeauty.