### PR TITLE
Return cocktail generator

### DIFF
--- a/MC/CustomGenerators/PWGLF/Box_Nuclex003.C
+++ b/MC/CustomGenerators/PWGLF/Box_Nuclex003.C
@@ -12,5 +12,6 @@ GeneratorCustom()
     //
     ctl->AddGenerator(box, "anti-3He", 1.0);
     //
+    return ctl;
 
 }


### PR DESCRIPTION
Hi @akalweit ,
I think in  PR #411 you forgot to return the cocktail generator as It is done for Box_Nuclex001 and Box_Nuclex002. I spotted this issue while simulating the anti-He3 passing in the detector and using your useful box (the simulation crashed) . Am I correct or am I missing something?
