### PR TITLE
Propagate energy, number of events and seed directly from dgpsim sett…

### DIFF
--- a/MC/aligenmc/gen_aligenmc.sh
+++ b/MC/aligenmc/gen_aligenmc.sh
@@ -8,4 +8,15 @@ fi
 
 echo "running in `pwd`, writing HepMC to $1"
 
-aligenmc ${ALIGENMC_PACKAGES:+-p $ALIGENMC_PACKAGES} ${ALIGENMC_GENERATOR:+-g $ALIGENMC_GENERATOR} ${ALIGENMC_OPTIONS:+$ALIGENMC_OPTIONS} -o $1
+echo "aligenmc configuration:" 
+echo "==========================================="
+echo "Generator:              $ALIGENMC_GENERATOR"
+echo "Number of events:       $CONFIG_NEVENTS"
+echo "CMS energy:             $CONFIG_ENERGY"
+echo "Random seed:            $CONFIG_SEED"
+echo "Pt-hard min:            $CONFIG_PTHARDMIN"
+echo "Pt-hard max:            $CONFIG_PTHARDMAX"
+echo "Packages:               $ALIGENMC_PACKAGES" 
+echo "Extra options:          $ALIGENMC_OPTIONS"
+
+aligenmc ${ALIGENMC_PACKAGES:+-p $ALIGENMC_PACKAGES} ${ALIGENMC_GENERATOR:+-g $ALIGENMC_GENERATOR} ${CONFIG_NEVENTS:+-N $CONFIG_NEVENTS} ${CONFIG_ENERGY:+-E $CONFIG_ENERGY} ${CONFIG_SEED:+-S $CONFIG_SEED}  ${CONFIG_PTHARDMIN:+-k $CONFIG_PTHARDMIN} ${CONFIG_PTHARDMAX:+-K $CONFIG_PTHARDMAX} ${ALIGENMC_OPTIONS:+$ALIGENMC_OPTIONS} -o $1


### PR DESCRIPTION
…ings to aligenmc

Use parameters for number of events, energy and seed
from DPG sim directly rather then passing them as
extra arguments via genopts. In addition log settings
in gen.log.