### PR TITLE
Custom generator trigger passed via dpgsim

### DIFF
--- a/MC/CustomGenerators/DPG/UserTriggerExample.C
+++ b/MC/CustomGenerators/DPG/UserTriggerExample.C
@@ -19,7 +19,7 @@
 Bool_t UserTriggerFunction(AliStack *stack)
 {
   printf("____________________________\n");
-  printf("USER TRIGGER IMPLEMENTATION \n");
+  printf("USER TRIGGER IMPLEMENTATION EXAMPLE\n");
 
   Int_t nTracks  = stack->GetNtrack();
   printf("n Tracks = %i \n",nTracks);
@@ -39,7 +39,7 @@ Bool_t UserTriggerFunction(AliStack *stack)
 //------
 /// Main, pass the generator and set the user trigger
 //------
-void UserTrigger(AliGenerator * generator)
+void GenTriggerCustom(AliGenerator * generator)
 {
   Bool_t (*funcUserTrigger)(AliStack*) = UserTriggerFunction;
   

--- a/MC/GeneratorConfig.C
+++ b/MC/GeneratorConfig.C
@@ -494,6 +494,61 @@ void GeneratorConfig(Int_t tag)
     }
   }
   
+  // Externally defined event trigger
+  
+  TString gentrigstr = gSystem->Getenv("CONFIG_GENTRIGGER");
+
+  // Custom external trigger
+  if ( gentrigstr == "Custom")
+  {
+    if ((gROOT->LoadMacro("GenTriggerCustom.C")) != 0) {
+      printf("ERROR: cannot find GenTriggerCustom.C\n");
+      abort();
+      return;
+    }
+        
+    // Load and compile macro
+    gROOT->LoadMacro("GenTriggerCustom.C+");
+    
+    gg_tmp_gen = gen;
+    gROOT->ProcessLine("GenTriggerCustom(gg_tmp_gen);");
+  }
+  else if (gentrigstr!="")
+  {
+    // PWG
+    TObjArray  *oa         = gentrigstr.Tokenize(":");
+    TObjString *pwgtrig    = (TObjString*) oa->At(0);
+    TObjString *pwgtriggen = (TObjString*) oa->At(1);
+    // In case we manage to pass an option to the function, not possible now
+    //TObjString *pwgtrigopt = (TObjString*) oa->At(2);
+    
+    if (!pwgtrig || !pwgtriggen) {
+      printf("ERROR: problem parsing CONFIG_GENTRIGGER: %s \n", gentrigstr.Data());
+      abort();
+      return;
+    }
+    
+    // load PWG custom trigger generator macro
+    TString pwgtrigmacro = "$ALIDPG_ROOT/MC/CustomGenerators/";
+    pwgtrigmacro += pwgtrig->GetString();
+    pwgtrigmacro += "/";
+    pwgtrigmacro += pwgtriggen->GetString();
+    pwgtrigmacro += ".C+";
+    
+    // Load and compile macro
+    if ( ( gROOT->LoadMacro(pwgtrigmacro.Data() ) ) != 0) {
+      printf("ERROR: cannot find %s \n", pwgtrigmacro.Data());
+      abort();
+      return;
+    }
+    
+    gg_tmp_gen = gen;
+    gROOT->ProcessLine("GenTriggerCustom(gg_tmp_gen);");
+  }
+  
+  // ////////////////////////////
+  
+  
   gen->Init();
   printf(">>>>> Generator Configuration: %s \n", comment.Data());
   // Set the trigger configuration: proton-proton

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -28,6 +28,7 @@ function COMMAND_HELP(){
     echo "--mode <mode>                 (mandatory) Running mode (ocdb,sim,rec,qa,aod,full,Muon,MuonOnly,Run3,extractembedded)" 
     echo "--run <run>                   (mandatory) Anchor run number"    
     echo "--generator <generatorConfig>             Mandatory for sim mode, choose: general purpose, PWG specific, or Custom (see TWiki)"
+    echo "--gentrigger <generatorTriggerConfig>     Generator event selected by external trigger PWG specific, or Custom  (see TWiki)"
     echo ""
     echo "Monte Carlo generation control:"
     echo "--nevents <numberOfEvents>                Number of events to be generated in the simulation stage"
@@ -183,6 +184,7 @@ CONFIG_NBKG=""
 CONFIG_BGEVDIR=""
 CONFIG_SEED="0"
 CONFIG_GENERATOR=""
+CONFIG_GENTRIGGER=""
 CONFIG_BACKGROUND=""
 OVERRIDE_BKG_PATH_RECORD=""
 CONFIG_PROCESS=""
@@ -276,6 +278,10 @@ while [ ! -z "$1" ]; do
     elif [ "$option" = "--generator" ]; then
         CONFIG_GENERATOR="$1"
 	export CONFIG_GENERATOR
+        shift
+    elif [ "$option" = "--gentrigger" ]; then
+        CONFIG_GENTRIGGER="$1"
+  export CONFIG_GENTRIGGER
         shift
     elif [ "$option" = "--genvertex" ]; then
         CONFIG_GENVERT="$1"
@@ -859,6 +865,7 @@ echo "Energy........... $CONFIG_ENERGY"
 echo "Detector mask.... $CONFIG_DETECTORMASK"
 echo "============================================"
 echo "Generator........ $CONFIG_GENERATOR"
+echo "Gen. evt. trig... $CONFIG_GENTRIGGER"
 echo "Process.......... $CONFIG_PROCESS"
 echo "No. Events....... $CONFIG_NEVENTS"
 echo "Unique-ID........ $CONFIG_UID"


### PR DESCRIPTION
As requested in DPG meeting 05/10/20, the possibility to recover the macro with event generator external trigger in the same way as for generators is implemented.
Example use cases:

- $ALIDPG_ROOT/bin/aliroot_dpgsim.sh --run 296196 --mode sim --simulation GeneratorOnly --uid 1 --nevents 10  --generator Pythia6 --gentrigger Custom (It needs to have locally the file GenTriggerCustom.C, before named UserTrigger.C)

- $ALIDPG_ROOT/bin/aliroot_dpgsim.sh --run 296196 --mode sim --simulation GeneratorOnly --uid 1 --nevents 10  --generator Pythia6 --gentrigger DPG:UserTriggerExample

Note that, 
* Now there is no need for the macros Pythia6_UserTrigger.C and EPOS_UserTrigger.C, the generator configuration is handled in the usual way. Maybe we should implement a warning for the generators this is not working, all but Pythia6 and those using AliGenExtFile
* The UserTriggerFunction must be implemented in a macro with method name GenTriggerCustom and for the "Custom" option the macro must be named GenTriggerCustom.C
* Right now, I do not see a way to pass settings to the trigger user function, which would be interesting to avoid many macros doing the same thing but just changing a number
* The PWG macros are now expected in the same directories as for the generators, it can be easily changed to other location, but I preferred to not add now more directories.

Tested on Root6 not yet on Root5, but it should.
