### PR TITLE
Special configs for HF productions in Pb-Pb

### DIFF
--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -727,8 +727,18 @@ void AddAnalysisTasks(const char *cdb_location, Bool_t isMC)
     {
 
       Int_t configHF=0;
+      TString specialConfig="";
       if(iCollision == kPbPb || iCollision == kXeXe) configHF=1;
-      AliAnalysisTaskSEVertexingHF *taskvertexingHF = AddTaskVertexingHF(configHF,train_name,"",run_number,periodName);
+      if(isMC && iCollision == kPbPb && year==2018){
+	Float_t bmin=0;
+	Float_t bmax=20;
+	if (gSystem->Getenv("CONFIG_BMIN")) bmin = atof(gSystem->Getenv("CONFIG_BMIN"));
+	if (gSystem->Getenv("CONFIG_BMAX")) bmax = atof(gSystem->Getenv("CONFIG_BMAX"));
+	if(bmin<6.5 &&  bmax<6.5) specialConfig="$ALICE_PHYSICS/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LcMinpt1_DsMinPt15_2018opt_Central.C";
+	if(bmin>5) specialConfig="$ALICE_PHYSICS/PWGHF/vertexingHF/ConfigVertexingHF_Pb_AllCent_NoLS_PIDLc_PtDepSel_LcMinpt1_DsMinPt15_2018opt_SemiCentral.C";
+	if(specialConfig.Length()>0) printf("Special config file will be used for VertexingHF: %s\n",specialConfig.Data());
+      }
+      AliAnalysisTaskSEVertexingHF *taskvertexingHF = AddTaskVertexingHF(configHF,train_name,specialConfig,run_number,periodName);
       // Now we need to keep in sync with the ESD filter
       if (!taskvertexingHF) ::Warning("AnalysisTrainNew", "AliAnalysisTaskSEVertexingHF cannot run for this train conditions - EXCLUDED");
       else mgr->RegisterExtraFile("AliAOD.VertexingHF.root");


### PR DESCRIPTION
This modification in main_AODtrainRawAndMC.C allows to set automaticallythe configuration for the vertexingHF filtering in the MC simulations anchored to 2018 Pb-Pb sample.
Some notes:
- the limits on the impact parameter, which are used to "decide" which of the configuration files should be used, are set based on the ones used in LHC20g2a and LHC20g2b productions. If in the future we are going to do a production in e.g. 10-20% or 20-30% centralities we may need to come back to them.
- to define automatically the configuration file based on the centrality interval of the MC production, I used the variables CONFIG_BMIN and CONFIG_BMAX, which are defined in the simulation script (dpgsim.sh). This means that this strategy would work for the AOD creation which runs in the reconstruction job. For the AOD refilterings, we would need to set by hand these variables when preparing the refiltering. This would complicate this refilteirng jobs with a setting that is production type dependent. However, also other possibilities (such as setting the name of the configuration file in the JDL) would have the same issue in the case of refilterings.

