### PR TITLE
Updated AOD macro FB for upcoming pass2 LHC18*

### DIFF
--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -1144,6 +1144,8 @@ void SetRunFlagForFilterBits(){
       else if((periodName.EqualTo("LHC16q") || periodName.EqualTo("LHC16r") ||
 	       periodName.EqualTo("LHC16s") || periodName.EqualTo("LHC16t")) && passName.EndsWith("pass2"))
 	run_flag = 1501;
+      else if(periodName.Contains("LHC18") && passName.EndsWith("pass2"))
+        run_flag = 1501;
     }
   if(year<=2010) 
     {


### PR DESCRIPTION
Ciao Chiara and Francesco,

For upcoming pass2 of 18l we'll need this update to set the proper FB for the AODs..
Please have a look then we need new tag before starting pass2.

Thanks!

Yours,
Catalin.
