### PR TITLE
Adds handling of Lc->Lpi forced decays in D2H generators

### DIFF
--- a/AOD/main_AODtrainRawAndMC.C
+++ b/AOD/main_AODtrainRawAndMC.C
@@ -902,7 +902,7 @@ void AODmerge()
   TStopwatch timer;
   timer.Start();
   TString outputDir = "wn.xml";
-  TString outputFiles = "EventStat_temp.root,AODQA.root,AliAOD.root,AliAOD.VertexingHF.root,AliAOD.Muons.root,AliAODGammaConversion.root,AliAOD.Jets.root,FilterEvents_Trees.root,pyxsec_hists.root";
+  TString outputFiles = "EventStat_temp_AODFiltering.root,AODQA.root,AliAOD.root,AliAOD.VertexingHF.root,AliAOD.Muons.root,AliAODGammaConversion.root,AliAOD.Jets.root,pyxsec_hists.root";
   TString mergeExcludes = "";
   TObjArray *list = outputFiles.Tokenize(",");
   TIter *iter = new TIter(list);

--- a/MC/CustomGenerators/PWGHF/Hijing_pPb_Pythia8_Monash2013_D2Hdedicated.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_pPb_Pythia8_Monash2013_D2Hdedicated.C
@@ -9,7 +9,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
 
   const Int_t nOptions=7;
   
-  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "LctoLpiDedicated"};
+  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "LcToLpiDedicated"};
 
   Int_t channelOption = 0;
   for (Int_t iopt = 0; iopt < nOptions; iopt++ ) {

--- a/MC/CustomGenerators/PWGHF/Hijing_pPb_Pythia8_Monash2013_D2Hdedicated.C
+++ b/MC/CustomGenerators/PWGHF/Hijing_pPb_Pythia8_Monash2013_D2Hdedicated.C
@@ -7,9 +7,9 @@ AliGenerator *GeneratorCustom(TString opt = "")
 		ctl->AddGenerator(hij, "Hijing", 1.);
 	}
 
-  const Int_t nOptions=6;
+  const Int_t nOptions=7;
   
-  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated"};
+  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "LctoLpiDedicated"};
 
   Int_t channelOption = 0;
   for (Int_t iopt = 0; iopt < nOptions; iopt++ ) {
@@ -18,8 +18,8 @@ AliGenerator *GeneratorCustom(TString opt = "")
   }
 
   //Switches for prompt/nonprompt, sign of trigger particle, trigger particle
-  Int_t triggerParticleFirst[nOptions] = {431, 431, 4132, 4122, 4122, 4132};
-  Int_t triggerParticleSecond[nOptions] = {0, 411, 4232, 0, 0, 0};
+  Int_t triggerParticleFirst[nOptions] = {431, 431, 4132, 4122, 4122, 4132, 4122};
+  Int_t triggerParticleSecond[nOptions] = {0, 411, 4232, 0, 0, 0, 0};
   Process_t process; //charm or beauty
   Int_t sign = 0; //Sign of trigger particle
   Int_t triggerPart = triggerParticleFirst[channelOption]; //trigger particle
@@ -85,6 +85,9 @@ AliGenerator *GeneratorCustom(TString opt = "")
         printf("ERROR: AliRoot version does not contain option for Xic semileptonic decay!\n");
         return 0x0;
       }
+    }
+    else if(channelOption==6) {
+       pyth->SetForceDecay(kLcLpi);
     }
     else if(channelOption<2 && argsNum>=5){
       pyth->SetForceDecay(kHadronicDWithout4BodiesDsPhiPi);
@@ -161,6 +164,11 @@ AliGenerator *GeneratorCustom(TString opt = "")
       Printf("Lc -> pK0s channel");
       (AliPythia8::Instance())->ReadString("4122:onMode = off");
       (AliPythia8::Instance())->ReadString("4122:onIfMatch = 2212 311");
+    }
+    else if(channelOption==6){
+      Printf("Lc -> Lambda pi channel");
+      (AliPythia8::Instance())->ReadString("4122:onMode = off");
+      (AliPythia8::Instance())->ReadString("4122:onIfMatch = 3122 211");
     }
   } 
   // Set up2date lifetimes for hadrons

--- a/MC/CustomGenerators/PWGHF/Pythia8_Monash2013_D2Hdedicated.C
+++ b/MC/CustomGenerators/PWGHF/Pythia8_Monash2013_D2Hdedicated.C
@@ -3,7 +3,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
 
   const Int_t nOptions=8;
   
-  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "OmegacDedicated","LctoLpiDedicated"};
+  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "OmegacDedicated","LcToLpiDedicated"};
 
   Int_t channelOption = 0;
   for (Int_t iopt = 0; iopt < nOptions; iopt++ ) {
@@ -81,7 +81,7 @@ AliGenerator *GeneratorCustom(TString opt = "")
       }
     }
     else if(channelOption==7) {
-       
+      pyth->SetForceDecay(kLcLpi);
     }
     else if(channelOption<2 && argsNum>=5){
       pyth->SetForceDecay(kHadronicDWithout4BodiesDsPhiPi);
@@ -166,11 +166,13 @@ AliGenerator *GeneratorCustom(TString opt = "")
       Printf("Lc -> Lpi channel");
       (AliPythia8::Instance())->ReadString("4122:onMode = off");
       (AliPythia8::Instance())->ReadString("4122:onIfMatch = 3122 211");
+    }
   } 
   // Set up2date lifetimes for hadrons
   // lambda_b from PDG 2019: tau0 = 1.471 ps = 441 m/c = 0.441 mm/c
   (AliPythia8::Instance())->ReadString("5122:tau0 = 4.41000e-01");
-
   
+
+
   return pyth;
 }

--- a/MC/CustomGenerators/PWGHF/Pythia8_Monash2013_D2Hdedicated.C
+++ b/MC/CustomGenerators/PWGHF/Pythia8_Monash2013_D2Hdedicated.C
@@ -1,9 +1,9 @@
 AliGenerator *GeneratorCustom(TString opt = "")
 {
 
-  const Int_t nOptions=7;
+  const Int_t nOptions=8;
   
-  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "OmegacDedicated"};
+  Char_t* label[nOptions] = {"DsDedicated", "DsDplusDedicated", "XicDedicated", "LcTopKpiDedicated", "LcTopK0sDedicated", "XicSemilepDedicated", "OmegacDedicated","LctoLpiDedicated"};
 
   Int_t channelOption = 0;
   for (Int_t iopt = 0; iopt < nOptions; iopt++ ) {
@@ -12,8 +12,8 @@ AliGenerator *GeneratorCustom(TString opt = "")
   }
 
   //Switches for prompt/nonprompt, sign of trigger particle, trigger particle
-  Int_t triggerParticleFirst[nOptions] = {431, 431, 4132, 4122, 4122, 4132, 4332};
-  Int_t triggerParticleSecond[nOptions] = {0, 411, 4232, 0, 0, 0, 0};
+  Int_t triggerParticleFirst[nOptions] = {431, 431, 4132, 4122, 4122, 4132, 4332, 4122};
+  Int_t triggerParticleSecond[nOptions] = {0, 411, 4232, 0, 0, 0, 0, 0};
   Process_t process; //charm or beauty
   Int_t sign = 0; //Sign of trigger particle
   Int_t triggerPart = triggerParticleFirst[channelOption]; //trigger particle
@@ -79,6 +79,9 @@ AliGenerator *GeneratorCustom(TString opt = "")
         printf("ERROR: AliRoot version does not contain option for Xic semileptonic decay!\n");
         return 0x0;
       }
+    }
+    else if(channelOption==7) {
+       
     }
     else if(channelOption<2 && argsNum>=5){
       pyth->SetForceDecay(kHadronicDWithout4BodiesDsPhiPi);
@@ -159,6 +162,10 @@ AliGenerator *GeneratorCustom(TString opt = "")
       (AliPythia8::Instance())->ReadString("4122:onMode = off");
       (AliPythia8::Instance())->ReadString("4122:onIfMatch = 2212 311");
     }
+    else if(channelOption==7){
+      Printf("Lc -> Lpi channel");
+      (AliPythia8::Instance())->ReadString("4122:onMode = off");
+      (AliPythia8::Instance())->ReadString("4122:onIfMatch = 3122 211");
   } 
   // Set up2date lifetimes for hadrons
   // lambda_b from PDG 2019: tau0 = 1.471 ps = 441 m/c = 0.441 mm/c


### PR DESCRIPTION
Adds new option, "LcToLpiDedicated", to the D2H custom generators for PYTHIA8 (pp) and HIJING+PYTHIA8 (p-Pb) in CustomGenerators.

Handling with new AliDecayer::kLcLpi option has dependency on AliRoot commit https://github.com/alisw/AliRoot/pull/1337 . 