### PR TITLE
Bunch of files for LF production with trigger on nuclei after trasport

### DIFF
--- a/MC/CustomGenerators/PWGLF/ReadKine.C
+++ b/MC/CustomGenerators/PWGLF/ReadKine.C
@@ -1,0 +1,63 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include <AliRun.h>
+#include <TParticle.h>
+#include <TString.h>
+#include <TTree.h>
+#include <TArrayF.h>
+#include <AliStack.h>
+#include <AliRunLoader.h>
+#include <TMath.h>
+#include <AliHeader.h>
+#include <AliGenEventHeader.h>
+#include <TH1F.h>
+#include <TNtuple.h>
+#include <TFile.h>
+#include <AliESD.h>
+#include <AliESDVertex.h>
+#endif
+
+void ReadKine()
+{
+  if (gAlice)
+  {
+    delete gAlice;
+    gAlice = 0x0;
+  }
+
+  AliRunLoader *rl = AliRunLoader::Open("galice.root");
+  if (rl == 0x0)
+  {
+    std::cerr << "Can not open session" << std::endl;
+    return;
+  }
+
+  rl->LoadHeader();
+  rl->LoadKinematics();
+  Int_t nev = rl->GetNumberOfEvents();
+  int codes[4] = {AliPID::ParticleCode(AliPID::kDeuteron), AliPID::ParticleCode(AliPID::kTriton), AliPID::ParticleCode(AliPID::kHe3), AliPID::ParticleCode(AliPID::kAlpha)};
+  for (Int_t iev = 0; iev < nev; iev++)
+  {
+    rl->GetEvent(iev);
+    AliStack *stack = rl->Stack();
+    TArrayF mcVertex(3);
+    rl->GetHeader()->GenEventHeader()->PrimaryVertex(mcVertex);
+    TTree *treek = (TTree *)rl->TreeK();
+    Int_t entries = (Int_t)treek->GetEntries();
+    printf("Number of particles = %d\n", entries);
+    for (Int_t i = 0; i < entries; i++)
+    {
+      TParticle *part = (TParticle *)stack->Particle(i);
+      Int_t pdgCode = part->GetPdgCode();
+      for (int iC = 0; iC < 4; ++iC) {
+        if (pdgCode == codes[iC]) {
+          if (stack->IsSecondaryFromMaterial(i)) {
+	    printf("Particle with pdg=%d FOUND IN KINE TREE\n",pdgCode);
+            exit(EXIT_SUCCESS);
+          }
+        }
+      }
+    }
+  }
+  exit(EXIT_FAILURE);
+}

--- a/MC/CustomGenerators/PWGLF/ReadKineAndHitsHe3.C
+++ b/MC/CustomGenerators/PWGLF/ReadKineAndHitsHe3.C
@@ -1,0 +1,135 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include <AliRun.h>
+#include <TParticle.h>
+#include <TString.h>
+#include <TTree.h>
+#include <TArrayF.h>
+#include <AliStack.h>
+#include <AliRunLoader.h>
+#include <TMath.h>
+#include <AliHeader.h>
+#include <AliGenEventHeader.h>
+#include <TH1F.h>
+#include <TNtuple.h>
+#include <TFile.h>
+#include <AliESD.h>
+#include <AliESDVertex.h>
+#include <AliITShit.h>
+#include <AliITSgeomTGeo.h>
+#include <AliTPCTrackHitsV2.h>
+#include <AliTPC.h>
+#endif
+
+void ReadKineAndHitsHe3()
+{
+  if (gAlice)
+  {
+    delete gAlice;
+    gAlice = 0x0;
+  }
+
+  AliRunLoader *rl = AliRunLoader::Open("galice.root");
+  if (rl == 0x0)
+  {
+    std::cerr << "Can not open session" << std::endl;
+    return;
+  }
+
+  rl->LoadHeader();
+  rl->LoadKinematics();
+  rl->LoadHits();
+  Int_t nev = rl->GetNumberOfEvents();
+  int triggerPDG = AliPID::ParticleCode(AliPID::kHe3);
+  for (Int_t iev = 0; iev < nev; iev++){
+    rl->GetEvent(iev);
+    AliStack *stack = rl->Stack();
+    TArrayF mcVertex(3);
+    rl->GetHeader()->GenEventHeader()->PrimaryVertex(mcVertex);
+    TTree *treek = (TTree *)rl->TreeK();
+    TTree *treeHits = (TTree *)rl->GetTreeH("ITS",kFALSE);
+    TTree *treeHtpc = (TTree *)rl->GetTreeH("TPC",kFALSE);
+    TClonesArray *arritsh=new TClonesArray("AliITShit",10000);
+    treeHits->SetBranchAddress("ITS",&arritsh);
+    AliTPCTrackHitsV2 *htpc= new AliTPCTrackHitsV2;
+    TBranch* branchHtpc=treeHtpc->GetBranch("TPC2");
+    branchHtpc->SetAddress(&htpc);
+
+    Int_t entries = (Int_t)treek->GetEntries();
+    printf("Number of particles = %d\n", entries);
+    for (Int_t iPart = 0; iPart < entries; iPart++){
+      TParticle *part = (TParticle *)stack->Particle(iPart);
+      Int_t pdgCode = part->GetPdgCode();
+      if (pdgCode == triggerPDG && stack->IsSecondaryFromMaterial(iPart)) {
+	Double_t rap=part->Y();
+	if(TMath::Abs(rap)<1.){
+	  Float_t vx = part->Vx();
+	  Float_t vy = part->Vy();
+	  Float_t vz = part->Vz();
+	  Float_t r  = TMath::Sqrt(vx * vx + vy * vy);
+	  Double_t minRadius=99999.;
+	  Double_t maxRadius=0.;
+	  Int_t hitInLay=0;
+	  Int_t nPrimTracks =(Int_t) treeHits->GetEntries();
+	  Int_t nPrimTracksTPC =(Int_t) treeHtpc->GetEntries();
+	  for(Int_t iPrimTrack=0; iPrimTrack<nPrimTracks; iPrimTrack++){
+	    Int_t nBytes = treeHits->GetEvent(iPrimTrack);
+	    if (nBytes <= 0) continue;
+	    Int_t nHits = arritsh->GetEntriesFast();
+	    for (Int_t ih=0; ih<nHits; ih++) {
+	      AliITShit *itsHit=(AliITShit*)arritsh->UncheckedAt(ih);
+	      if(itsHit->GetTrack()==iPart){
+		Double_t xg,yg,zg,tof;
+		itsHit->GetPositionG(xg,yg,zg,tof);
+		Int_t lay,lad,det;
+		AliITSgeomTGeo::GetModuleId(itsHit->GetModule(),lay,lad,det);
+		Double_t rhit= TMath::Sqrt(xg*xg+yg*yg);
+		if(rhit<minRadius) minRadius=rhit;
+		if(rhit>maxRadius) maxRadius=rhit;
+		hitInLay|=(1<<(lay-1));
+		//		    printf("Hit %d %d  track %d module %d lay %d coord = %f %f %f rad=%f\n",iPrimTrack,ih,itsHit->GetTrack(),itsHit->GetModule(),lay,xg,yg,zg,rhit);
+	      }
+	    }
+	  }
+	  Int_t nITShits=0;
+	  for(Int_t iLay=0; iLay<6; iLay++) if(hitInLay & (1<<iLay)) nITShits++;
+	  Int_t nTPChits=0;
+	  for(Int_t iPrimTrack=0; iPrimTrack<nPrimTracksTPC; iPrimTrack++){
+	    Int_t nBytes = branchHtpc->GetEvent(iPrimTrack);
+	    if (nBytes <= 0) continue;
+	    TClonesArray* arrtpch=htpc->GetArray();
+	    Int_t nHtpc = arrtpch->GetEntriesFast();
+	    for (Int_t ih=0; ih<nHtpc; ih++) {
+	      AliTPChit *tpcHit=(AliTPChit*)arrtpch->UncheckedAt(ih);
+	      if(tpcHit->GetTrack()==iPart){
+		Double_t xg=tpcHit->X();
+		Double_t yg=tpcHit->Y();
+		Double_t zg=tpcHit->Z();
+		Double_t rhit= TMath::Sqrt(xg*xg+yg*yg);
+		if(rhit>50) { // Skip hits at interaction point
+		  //		      printf("Hit %d in TPC = %f %f\n",ih,rhit,zg);
+		  if(rhit<minRadius) minRadius=rhit;
+		  if(rhit>maxRadius) maxRadius=rhit;
+		  nTPChits++;
+		}
+	      }
+	    }
+	  }
+	  printf("Particle with pdg=%d and y=%f and r=%f  z=%f  FOUND IN KINE TREE\n",pdgCode,rap,r,vz);
+	  printf("nITS hits = %d  nTPChits = %d min hit radius = %f  max hit radius = %f\n",nITShits,nTPChits,minRadius,maxRadius);
+	  if(nITShits>=2 && maxRadius>140){
+	    printf("--> accepted\n");
+	    delete arritsh;
+	    delete htpc;
+	    exit(EXIT_SUCCESS);
+	  }else{
+	    printf("--> not enough hits and length\n");
+	  }
+	}
+      }
+    }
+    delete arritsh;
+    delete htpc;
+  }
+  exit(EXIT_FAILURE);
+}

--- a/MC/Digitize.C
+++ b/MC/Digitize.C
@@ -1,0 +1,94 @@
+/*
+ * AliDPG - ALICE Experiment Data Preparation Group
+ * Simulation steering script
+ *
+ */
+
+/*****************************************************************/
+/*****************************************************************/
+/*****************************************************************/
+
+#if (!defined(__CLING__) && !defined(__CINT__)) || defined(__ROOTCLING__) || defined(__ROOTCINT__)
+#include "TSystem.h"
+#include "TROOT.h"
+#include "AliSimulation.h"
+#endif
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#include "SimulationConfig.C"
+#endif
+
+void Digitize() 
+{
+
+  // number of events configuration
+  Int_t nev = 200;
+  if (gSystem->Getenv("CONFIG_NEVENTS"))
+    nev = atoi(gSystem->Getenv("CONFIG_NEVENTS"));
+  
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+  // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
+#else
+  gROOT->LoadMacro("$ALIDPG_ROOT/MC/SimulationConfig.C");
+#endif
+  
+  // simulation configuration
+  ESimulation_t simulationConfig = kSimulationDefault;
+  if (gSystem->Getenv("CONFIG_SIMULATION")) {
+    Bool_t valid = kFALSE;
+    for (Int_t isim = 0; isim < kNSimulations; isim++)
+      if (strcmp(gSystem->Getenv("CONFIG_SIMULATION"), SimulationName[isim]) == 0) {
+        simulationConfig = (ESimulation_t) isim;
+        valid = kTRUE;
+        break;
+      }
+    if (!valid) {
+      printf(">>>>> Unknown simulation configuration: %s \n", gSystem->Getenv("CONFIG_SIMULATION"));
+      abort();
+    }
+  }
+
+  /* initialisation */
+  Int_t error;
+  TString config_macro = "$ALIDPG_ROOT/MC/Config.C";
+  if (gROOT->LoadMacro(Form("%s/Config.C", gSystem->pwd()), &error, kTRUE) == 0) {
+    printf(">>>>> Config.C macro detected in CWD, using that one \n");
+    config_macro = Form("%s/Config.C", gSystem->pwd());
+  }
+  gROOT->LoadMacro("$ALIDPG_ROOT/MC/Config_LoadLibraries.C");
+  gROOT->ProcessLine("Config_LoadLibraries();");
+
+  AliGeomManager::LoadGeometry("geometry.root");
+  AliRunLoader* rl = AliRunLoader::Open("galice.root");
+  rl->LoadgAlice();
+  AliRunLoader::Instance()->CdGAFile();
+  gAlice->InitLoaders();
+  AliRunLoader::Instance()->LoadKinematics();
+  AliRunLoader::Instance()->LoadTrackRefs();
+  AliRunLoader::Instance()->LoadHits();
+
+   
+  AliSimulation sim(config_macro.Data());
+  /* configuration */
+  SimulationConfig(sim, simulationConfig);
+
+  AliCDBManager::Instance()->SetSnapshotMode("OCDBsim.root");
+  AliCDBManager::Instance()->SetRun(atoi(gSystem->Getenv("CONFIG_RUN")));
+  AliGRPManager grpM;
+  grpM.ReadGRPEntry();
+  grpM.SetMagField();
+  
+  sim.SetRunGeneration(false);
+  sim.SetRunSimulation(false);
+  sim.Run(nev);
+
+  
+  // TString sdig = "TRD TOF PHOS HMPID EMCAL MUON ZDC PMD T0 VZERO FMD AD";
+  // TString h2dig = "ITS TPC";
+  // sim.RunSDigitization(sdig.Data());
+  // sim.RunDigitization("ALL", h2dig.Data());
+  // sim.RunHitsDigitization(h2dig.Data());
+  // sim.RunTrigger();
+  // sim.RunHLT();
+}
+

--- a/MC/Generate.C
+++ b/MC/Generate.C
@@ -1,0 +1,74 @@
+/*
+ * AliDPG - ALICE Experiment Data Preparation Group
+ * Simulation steering script
+ *
+ */
+
+/*****************************************************************/
+/*****************************************************************/
+/*****************************************************************/
+
+#if (!defined(__CLING__) && !defined(__CINT__)) || defined(__ROOTCLING__) || defined(__ROOTCINT__)
+#include "TSystem.h"
+#include "TROOT.h"
+#include "AliSimulation.h"
+#endif
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+#include "SimulationConfig.C"
+#endif
+
+void Generate() 
+{
+
+  // number of events configuration
+  Int_t nev = 200;
+  if (gSystem->Getenv("CONFIG_NEVENTS"))
+    nev = atoi(gSystem->Getenv("CONFIG_NEVENTS"));
+  
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
+  // in root5 the ROOT_VERSION_CODE is defined only in ACLic mode
+#else
+  gROOT->LoadMacro("$ALIDPG_ROOT/MC/SimulationConfig.C");
+#endif
+  
+  // simulation configuration
+  ESimulation_t simulationConfig = kSimulationDefault;
+  if (gSystem->Getenv("CONFIG_SIMULATION")) {
+    Bool_t valid = kFALSE;
+    for (Int_t isim = 0; isim < kNSimulations; isim++)
+      if (strcmp(gSystem->Getenv("CONFIG_SIMULATION"), SimulationName[isim]) == 0) {
+        simulationConfig = (ESimulation_t) isim;
+        valid = kTRUE;
+        break;
+      }
+    if (!valid) {
+      printf(">>>>> Unknown simulation configuration: %s \n", gSystem->Getenv("CONFIG_SIMULATION"));
+      abort();
+    }
+  }
+
+  /* initialisation */
+  Int_t error;
+  TString config_macro = "$ALIDPG_ROOT/MC/Config.C";
+  if (gROOT->LoadMacro(Form("%s/Config.C", gSystem->pwd()), &error, kTRUE) == 0) {
+    printf(">>>>> Config.C macro detected in CWD, using that one \n");
+    config_macro = Form("%s/Config.C", gSystem->pwd());
+  }
+  gROOT->LoadMacro("$ALIDPG_ROOT/MC/Config_LoadLibraries.C");
+  gROOT->ProcessLine("Config_LoadLibraries();");
+  AliSimulation sim(config_macro.Data());
+
+  /* configuration */
+  SimulationConfig(sim, simulationConfig);
+
+  /* run generation */
+  sim.SetMakeSDigits("");
+  sim.SetMakeDigits("");
+  sim.SetMakeDigitsFromHits("");
+  sim.SetWriteRawData("");
+  sim.SetRunHLT("");
+  sim.Run(nev);
+  
+}
+

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -1047,7 +1047,7 @@ if [[ $CONFIG_MODE == *"sim"* ]] || [[ $CONFIG_MODE == *"full"* ]]; then
 	    echo "* EVENT SELECTION : $CONFIG_SELEVMACRO" >&2
 	    echo "* EVENT SELECTION : output log in tag.log" >&2
 	    
-	    time aliroot -b -q -x $CONFIG_SELEVMACRO > tag.log 2>&1
+	    aliroot -b -q -x ${CONFIG_SELEVMACRO}+ > tag.log 2>&1
 	    exitcode=$?
 	    isthere="$(grep "FOUND IN KINE TREE" tag.log)"
 	    echo $isthere
@@ -1059,7 +1059,11 @@ if [[ $CONFIG_MODE == *"sim"* ]] || [[ $CONFIG_MODE == *"full"* ]]; then
 		echo "Requested particle not found -> generate another event"
 		rm *.Hits.root galice.root Kinematics.root TrackRefs.root geometry.root sim.log
 		jtry=$((jtry+1))
-		CONFIG_SEED=$(($CONFIG_SEED+1))
+                CONFIG_SEED=($(awk -v ranseed=$CONFIG_SEED 'BEGIN {
+                                   srand(ranseed)
+                                   k=rand()
+                                   print int(1 + k * 10000000)
+                                   }'))
 		echo "New seed" $CONFIG_SEED
 	    fi
 	done


### PR DESCRIPTION
These are the commits needed to run the production of ALIROOT-8651 with the selection of events after the trigger.
The strategy is to generate one event, run the transport, and run a macro to read the Kinematics (and the Hits) to check for specific particles and decide whether to go on with the digitisation.

Description of the code updates: I added an argument to dpgsim.sh to enable the "mode" with generation->selection-> digitization. It can be enabled with:
--selectevents SelMacro.C
where SelMacro.C is the name of the macro that will be used to select the events.
Note that the approach with --selectevents works properly only when we generate more than 1 event per job.

Still to be added to run the actual production:
- the final version of the macro to select the signals
- possibly a new generator configuration for PYTHIA8 with the possibility of setting a multiplicity threshold