### PR TITLE
Enable FOCAL simulations with alidpg

### DIFF
--- a/MC/Config_LoadLibraries.C
+++ b/MC/Config_LoadLibraries.C
@@ -36,6 +36,14 @@ Config_LoadLibraries()
   } 
   TString isFluka = gSystem->Getenv("CONFIG_FLUKA");
   if (isFluka!="on") gSystem->Load("libgeant321");
-
+  
+  if (gSystem->Getenv("CONFIG_DETECTOR")) {
+    if (strcmp(gSystem->Getenv("CONFIG_DETECTOR"), "FOCAL") == 0) {
+      printf(">>>>> Load FOCAL libs \n");
+      gSystem->Load("libFOCALbase");
+      gSystem->Load("libFOCALgen");
+      gSystem->Load("libFOCALsim");
+    }
+  }
 }
 

--- a/MC/CustomGenerators/Upgrade/FOCAL_Generators.C
+++ b/MC/CustomGenerators/Upgrade/FOCAL_Generators.C
@@ -1,0 +1,277 @@
+Double_t EtaToTheta(Double_t eta)
+{
+  return 2*TMath::ATan(TMath::Exp(-eta))*180/TMath::Pi();
+}
+
+// Generators for FOCAL simulations
+enum GenTypes : Int_t {
+    gun=0, 
+    box, 
+    pythia, 
+    pythia_MBtrig, 
+    pythia_dirgamma_trig, 
+    ntuple, 
+    hijing, 
+    hijingAP, 
+    PA_cocktail_dirgam, 
+    PA_cocktail_MBtrig, 
+    PA_cocktail_EPOS_MBtrig, 
+    PA_cocktail_EPOS_dirgam,
+    kNGenTypes
+};
+
+TString gGenTypeNames[kNGenTypes] = {
+    "gun", 
+    "box", 
+    "pythia", 
+    "pythia_MBtrig", 
+    "pythia_dirgamma_trig",
+    "ntuple",
+    "hijing",
+    "hijingAP",
+    "PA_cocktail_dirgam",
+    "PA_cocktail_MBtrig",
+    "PA_cocktail_EPOS_MBtrig",
+    "PA_cocktail_EPOS_dirgam"
+};
+
+Int_t gNtracks = 1;
+
+AliGenerator* GeneratorCustom(TString opt = "") {
+
+  Int_t generatorType = gun;
+  
+  for (Int_t iopt = 0; iopt < kNGenTypes; iopt++)
+    if (opt.EqualTo(gGenTypeNames[iopt]))
+      generatorType = iopt;
+    
+  //switch between the different generators
+  AliGenerator * generator = 0x0;
+  switch(generatorType) {
+    case gun:
+    // Example for Fixed Particle Gun             
+    {
+      AliGenFixed *gener = new AliGenFixed(gNtracks);
+	  gener->SetMomentum(500.);
+	  gener->SetPhi(0.);
+	  //gener->SetTheta(0.0556*180./TMath::Pi());   // to hit FOCAL at 20cm from beam axis at Z=360cm
+	  gener->SetTheta(EtaToTheta(4.5));
+	  gener->SetOrigin(0,0,0);        //vertex position
+	  gener->SetPart(kGamma);
+	  //gener->SetPart(kPiPlus);
+	  generator = gener;
+    }
+    break;
+
+    case box:  
+    // Example for Moving Particle Gun  
+    {
+      AliGenBox *gener = new AliGenBox(gNtracks);
+	  //gener->SetMomentumRange(49.999,50.001);
+	  gener->SetPtRange(0.,20.);
+	  gener->SetPhiRange(0.,360.);  // full polar angle around beam axis
+	  gener->SetEtaRange(3.5, 5.8);
+	  gener->SetOrigin(0,0,0);   
+	  //vertex position
+	  gener->SetSigma(0,0,0);         //Sigma in (X,Y,Z) (cm) on IP position
+	  gener->SetPart(kPi0);
+	  generator = gener;
+    }
+    break;
+
+    case pythia:
+    // Example for Pythia            
+    {
+	  AliGenPythia *gener = new AliGenPythia(-1); 
+	  gener->SetMomentumRange(0,999999); 
+	  gener->SetThetaRange(0., 45.); 
+	  gener->SetYRange(-12,12); 
+	  gener->SetPtRange(0,1000); 
+	  gener->SetProcess(kPyMb); // Min. bias events 
+	  gener->SetEnergyCMS(14000.); // LHC energy 
+	  //gener->SetOrigin(0, 0, 0); // Vertex position 
+	  gener->SetSigma(0, 0, 5.3); // Sigma in (X,Y,Z) (cm) on IP position 
+	  gener->SetCutVertexZ(1.); // Truncate at 1 sigma 
+	  gener->SetVertexSmear(kPerEvent); // Smear per event 
+	  gener->SetTrackingFlag(1); // Particle transport 
+	  generator = gener;
+    }
+    break;
+
+    case pythia_MBtrig:
+    case pythia_dirgamma_trig:
+    // Example for Pythia            
+    {
+      AliGenPythiaFOCAL *gener = new AliGenPythiaFOCAL(-1); 
+	  gener->SetMomentumRange(0,999999); 
+	  gener->SetThetaRange(0., 45.); 
+	  gener->SetYRange(-12,12); 
+	  gener->SetPtRange(0,1000); 
+	  gener->SetEnergyCMS(14000.); // LHC energy 
+	  //gener->SetOrigin(0, 0, 0); // Vertex position 
+	  gener->SetSigma(0, 0, 5.3); // Sigma in (X,Y,Z) (cm) on IP position 
+	  gener->SetCutVertexZ(1.); // Truncate at 1 sigma 
+	  gener->SetVertexSmear(kPerEvent); // Smear per event 
+	  gener->SetTrackingFlag(1); // Particle transport 
+      //gener->SetEtaInFOCAL(kTRUE);
+      //gener->SetPi0InFOCAL(kTRUE);
+      if (generatorType == pythia_MBtrig) {
+	    gener->SetProcess(kPyMb); // Min. bias events 
+        gener->SetDecayPhotonInFOCAL(kTRUE);
+      }
+      else {
+	    gener->SetProcess(kPyDirectGamma);
+        gener->SetFragPhotonInFOCAL(kTRUE);
+      }
+      gener->SetCheckFOCAL(kTRUE);  
+      gener->SetFOCALEta(3.5, 6.2);
+      gener->SetTriggerParticleMinPt(4.0);
+      generator = gener;
+    }
+    break;
+      
+    case ntuple:
+    // Example for reading from a external file             *
+    {
+  	  AliGenExtFile *gener = new AliGenExtFile(-1); 
+	  //gener->SetVertexSmear(kPerEvent); 
+	  gener->SetTrackingFlag(1);
+	
+	  AliGenReaderTreeK * reader = new AliGenReaderTreeK();
+	  reader->SetFileName("sim1/galice.root");
+	  gener->SetReader(reader);
+	  generator = gener;
+    }
+    break;
+
+    case hijing:
+    // Example for reading from a external file             *
+    {
+      AliGenHijing *gener = new AliGenHijing(-1); 
+      gener->SetEnergyCMS(5500.); // center of mass energy 
+      gener->SetReferenceFrame("CMS"); // reference frame 
+      gener->SetProjectile("A", 208, 82); // projectile 
+      gener->SetTarget ("A", 208, 82); // projectile 
+      gener->KeepFullEvent(); // HIJING will keep the full parent child chain 
+      gener->SetJetQuenching(1); // enable jet quenching 
+      gener->SetShadowing(1); // enable shadowing 
+      gener->SetDecaysOff(1); // neutral pion and heavy particle decays switched off 
+      gener->SetSpectators(0); // Don't track spectators 
+      gener->SetSelectAll(0); // kinematic selection 
+      gener->SetImpactParameterRange(0., 15.); // Impact parameter range (fm) 
+      generator = gener;
+    }
+    break;
+      
+    case hijingAP:
+    {
+      AliGenHijingFOCAL *gener = new AliGenHijingFOCAL(); 
+      gener->SetEnergyCMS(8790.); // center of mass energy 
+      gener->SetReferenceFrame("CMS"); // reference frame 
+      gener->SetBoostLHC(0.0);   // No boost for now; need to check sign
+      gener->SetProjectile("A", 208, 82); // projectile proton
+      gener->SetTarget ("P", 1, 1); // projectile Pb nucleus
+      gener->KeepFullEvent(); // HIJING will keep the full parent child chain 
+      gener->SetJetQuenching(1); // enable jet quenching 
+      gener->SetShadowing(1); // enable shadowing 
+      gener->SetDecaysOff(1); // neutral pion and heavy particle decays switched off 
+      gener->SetSpectators(0); // Don't track spectators 
+      gener->SetSelectAll(0); // kinematic selection 
+      gener->SetImpactParameterRange(0., 8.); // Impact parameter range (fm) 
+      //gener->UnsetDataDrivenSpectators();
+
+      gener->SetTrigger(2); // 2: direct photons; 3: decay photons
+      gener->SetPtJet(4.);
+      gener->SetJetEtaRange(3.5,5.8);
+      generator = gener;
+    }
+    break;
+      
+    case PA_cocktail_dirgam:
+    case PA_cocktail_MBtrig:
+    {
+      AliGenCocktail *cocktail = new AliGenCocktail();
+      cocktail->SetOrigin(0, 0, 0); // Vertex position
+      cocktail->SetSigma(0, 0, 5.8); // Sigma in (X,Y,Z) (cm) on IP position
+	  cocktail->SetVertexSmear(kPerEvent); // Smear per event
+
+      AliGenHijing *hijing = new AliGenHijing(-1); 
+      hijing->SetEnergyCMS(8790.); // center of mass energy 
+      hijing->SetReferenceFrame("CMS"); // reference frame 
+      hijing->SetBoostLHC(0.0);   // No boost for now; need to check sign
+      hijing->SetProjectile("A", 208, 82); // projectile proton
+      hijing->SetTarget ("P", 1, 1); // projectile Pb nucleus
+      hijing->KeepFullEvent(); // HIJING will keep the full parent child chain 
+      hijing->SetJetQuenching(1); // enable jet quenching 
+      hijing->SetShadowing(1); // enable shadowing 
+      hijing->SetDecaysOff(1); // neutral pion and heavy particle decays switched off 
+      hijing->SetSpectators(0); // Don't track spectators 
+      hijing->SetSelectAll(0); // kinematic selection 
+      hijing->SetImpactParameterRange(0., 15.); // Impact parameter range (fm) 
+      //hijing->UnsetDataDrivenSpectators();
+      cocktail->AddGenerator(hijing,"Hijing",1.);
+
+      AliGenPythiaFOCAL *pythia = new AliGenPythiaFOCAL(-1);
+	  pythia->SetMomentumRange(0,999999);
+      pythia->SetThetaRange(0., 45.);
+      pythia->SetYRange(-12,12);
+	  pythia->SetPtRange(0,1000);
+	  pythia->SetEnergyCMS(8790.); // LHC energy
+	  pythia->SetTrackingFlag(1); // Particle transport
+      if (generatorType == PA_cocktail_dirgam) {
+        pythia->SetProcess(kPyDirectGamma); // Direct photon events
+	    pythia->SetFragPhotonInFOCAL(kTRUE);
+      }
+      else {
+        pythia->SetProcess(kPyMb); // MB events
+	    pythia->SetDecayPhotonInFOCAL(kTRUE);
+      }
+      pythia->SetCheckFOCAL(kTRUE);
+      pythia->SetFOCALEta(3.5, 5.9);
+      pythia->SetTriggerParticleMinPt(4.0);
+      cocktail->AddGenerator(pythia,"Pythia",1.);
+
+      generator = cocktail;	
+    }
+    break;
+
+    case PA_cocktail_EPOS_dirgam:
+    case PA_cocktail_EPOS_MBtrig:
+    {
+      AliGenCocktailFOCAL *cocktail = new AliGenCocktailFOCAL();
+      cocktail->SetOrigin(0, 0, 0); // Vertex position
+      cocktail->SetSigma(0, 0, 5.8); // Sigma in (X,Y,Z) (cm) on IP position
+      cocktail->SetVertexSmear(kPerEvent); // Smear per event
+
+      TString fifoname("$TMPDIR/myfifo");
+      AliGenExtExec* eposExt = new AliGenExtExec();
+      eposExt->SetPathScript(Form("./gen_eposlhc.sh %s",fifoname.Data()));
+      eposExt->SetPathFIFO(fifoname);
+      cocktail->AddGenerator(eposExt,"EPOS",1.);
+
+      AliGenPythiaFOCAL *pythia = new AliGenPythiaFOCAL(-1);
+      pythia->SetMomentumRange(0,999999);
+      pythia->SetThetaRange(0., 45.);
+      pythia->SetYRange(-12,12);
+      pythia->SetPtRange(0,1000);
+      pythia->SetEnergyCMS(8790.); // LHC energy
+      pythia->SetTrackingFlag(1); // Particle transport
+      if (generatorType == PA_cocktail_EPOS_dirgam) {
+        pythia->SetProcess(kPyDirectGamma); // Direct photon events
+        pythia->SetFragPhotonInFOCAL(kTRUE);
+	    pythia->SetCheckFOCAL(kTRUE);
+	    pythia->SetFOCALEta(3.5, 5.9);
+	    pythia->SetTriggerParticleMinPt(4.0);
+      } else {
+        pythia->SetProcess(kPyMb); // MB events
+        //pythia->SetDecayPhotonInFOCAL(kTRUE);
+      } 
+      cocktail->AddGenerator(pythia,"Pythia",1.);
+      cocktail->SetTriggerKinematics(4.0,3.5,5.9);
+      generator = cocktail;
+    }
+    break;
+  }  // end switch
+  
+  return generator;
+}

--- a/MC/DetectorConfig.C
+++ b/MC/DetectorConfig.C
@@ -15,6 +15,7 @@ enum EDetector_t {
   kDetectorNoZDC,
   kDetectorCentralBarrelTracking,
   kDetectorRun3,
+  kDetectorFOCAL,
   kDetectorCustom,
   kNDetectors
 };
@@ -26,6 +27,7 @@ const Char_t *DetectorName[kNDetectors] = {
   "NoZDC",
   "CentralBarrelTracking",
   "Run3",
+  "FOCAL",
   "Custom"
 };
 
@@ -74,6 +76,7 @@ Int_t iVZERO  = 1;
 Int_t iZDC    = 1;
 Int_t iMFT    = 0;
 Int_t iFIT    = 0;
+Int_t iFOCAL  = 0;
   
 void DetectorDefault();
 void DetectorMuon();
@@ -128,6 +131,17 @@ DetectorConfig(Int_t tag)
   case kDetectorRun3:
     DetectorRun3();
     break;
+    
+  case kDetectorFOCAL:
+    DetectorDefault();
+    iFMD = 0;
+    iT0 = 0;
+    iZDC = 0;
+    iVZERO = 0;
+    iAD = 0;
+    iFIT = 1;
+    iFOCAL = 1;
+    break;  
     
     // kDetectorCustom
   case kDetectorCustom:
@@ -339,8 +353,18 @@ DetectorInit(Int_t tag)
   if (iPIPE)
     {
       //=================== PIPE parameters ============================
-
-      AliPIPE *PIPE = new AliPIPEv3("PIPE", "Beam Pipe");
+      if(tag == kDetectorFOCAL) {
+        AliPIPEFOCAL *PIPE = new AliPIPEFOCAL("PIPE", "Beam Pipe");
+        PIPE->SetConical(35,400);
+        PIPE->SetZflange(483.8);
+        PIPE->SetR2(3.6);
+        PIPE->SetIsConeBe(1);
+        PIPE->SetIsFlangeBe(1);
+        PIPE->SetConeW(0.1);
+      }
+      else {
+        AliPIPE *PIPE = new AliPIPEv3("PIPE", "Beam Pipe");
+      }
     }
  
   if (iITS)
@@ -575,6 +599,21 @@ DetectorInit(Int_t tag)
      else {
 	    Printf("AD is disabled, as we are using Fluka");
      }
+  }
+  
+  if (iFOCAL)
+  {
+    //=================== FOCAL parameters ============================
+    const char *gfname="";
+    if (gSystem->Getenv("CONFIG_FOCALGEOMETRYFILE")) {
+        gfname = gSystem->Getenv("CONFIG_FOCALGEOMETRYFILE");
+    }
+    AliFOCAL *FOCAL = new AliFOCALv1("FOCAL","FOCAL with HCAL at 7m",gfname);
+  }
+  
+  if (iFIT)
+  {
+    AliFIT *fit = new AliFITv8("FIT","FIT");
   }
 
 }

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -77,6 +77,7 @@ function COMMAND_HELP(){
     echo "--genopt                                  if using ALIGENMC as generator: optional arguments"
     echo "--tpcExtraDist                            apply extra CoverVoltage distortions in TPC simulation"
     echo "--cleanEsd <on|off>                       force cleanESD on/off for reconstruction, default is OFF for reconstructions done prior Dec,18 and ON after"
+    echo "--focalGeometryFile                       FOCAL geometry file"
     echo ""
     echo "Override automatic settings:"
     echo "--energy <energy>                         Centre-of-mass energy" 
@@ -250,6 +251,7 @@ CONFIG_SIGNALFILTERING="off"
 CONFIG_OCDBTIMESTAMP=""
 CONFIG_DEBUG=""
 CONFIG_CLEANESD=""
+CONFIG_FOCALGEOMETRYFILE=""
 
 RUNMODE=""
 
@@ -311,6 +313,13 @@ while [ ! -z "$1" ]; do
 #        shift
     elif [ "$option" = "--detector" ]; then
         CONFIG_DETECTOR="$1"
+         # check that FOCAL env is set in case we run a FOCAL simulation
+        if [ "$CONFIG_DETECTOR" = "FOCAL" ]; then
+            if [ -z "$FOCAL" ]; then
+                echo "FOCAL simulation requested but FOCAL environment not set."
+                exit 1
+            fi
+        fi
 	export CONFIG_DETECTOR
         shift
     elif [ "$option" = "--phostimeres" ]; then
@@ -506,6 +515,9 @@ while [ ! -z "$1" ]; do
 #	shift
     elif [ "$option" = "--cleanEsd" ]; then
         export CONFIG_CLEANESD="$1"
+        shift
+    elif [ "$option" = "--focalGeometryFile" ]; then
+        export CONFIG_FOCALGEOMETRYFILE="$1"
         shift
     fi
 done
@@ -988,92 +1000,91 @@ if [[ $CONFIG_MODE == *"sim"* ]] || [[ $CONFIG_MODE == *"full"* ]]; then
     # embedding using already generated background
     if [[ $CONFIG_BACKGROUND == *galice.root ]]; then
 
-	echo ">>>>> EMBEDDING: request to embed $CONFIG_GENERATOR signal in $CONFIG_BACKGROUND background"
-	export CONFIG_SIMULATION="EmbedSig"	
-	export CONFIG_BGEVDIR=${CONFIG_BACKGROUND%galice.root}
+        echo ">>>>> EMBEDDING: request to embed $CONFIG_GENERATOR signal in $CONFIG_BACKGROUND background"
+        export CONFIG_SIMULATION="EmbedSig"	
+        export CONFIG_BGEVDIR=${CONFIG_BACKGROUND%galice.root}
 	
-    # embedding using on-the-fly generated background
+        # embedding using on-the-fly generated background
     elif [[ $CONFIG_BACKGROUND != "" ]]; then
 
-	CONFIG_BGEVDIR=$CONFIG_BACKGROUND
-	export CONFIG_BGEVDIR
+        CONFIG_BGEVDIR=$CONFIG_BACKGROUND
+        export CONFIG_BGEVDIR
 
-	echo ">>>>> EMBEDDING: request to embed $CONFIG_GENERATOR signal in $CONFIG_BACKGROUND background"
+        echo ">>>>> EMBEDDING: request to embed $CONFIG_GENERATOR signal in $CONFIG_BACKGROUND background"
 
-	if [[ $CONFIG_NBKG == "" ]]; then
-	    export CONFIG_NBKG=1
-	fi
+        if [[ $CONFIG_NBKG == "" ]]; then
+            export CONFIG_NBKG=1
+        fi
 	
-	SAVE_CONFIG_GENERATOR=$CONFIG_GENERATOR
-	SAVE_CONFIG_NEVENTS=$CONFIG_NEVENTS
-	SAVE_CONFIG_SIMULATION=$CONFIG_SIMULATION
-	export CONFIG_GENERATOR=$CONFIG_BACKGROUND
-	export CONFIG_NEVENTS=$CONFIG_NBKG
-	export CONFIG_SIMULATION="EmbedBkg"
-	export CONFIG_BGEVDIR="BKG"
+        SAVE_CONFIG_GENERATOR=$CONFIG_GENERATOR
+        SAVE_CONFIG_NEVENTS=$CONFIG_NEVENTS
+        SAVE_CONFIG_SIMULATION=$CONFIG_SIMULATION
+        export CONFIG_GENERATOR=$CONFIG_BACKGROUND
+        export CONFIG_NEVENTS=$CONFIG_NBKG
+        export CONFIG_SIMULATION="EmbedBkg"
+        export CONFIG_BGEVDIR="BKG"
 	
-	mkdir $CONFIG_BGEVDIR
-	cp OCDB*.root *.C $CONFIG_BGEVDIR/.
-	cd $CONFIG_BGEVDIR
+        mkdir $CONFIG_BGEVDIR
+        cp OCDB*.root *.C $CONFIG_BGEVDIR/.
+        cd $CONFIG_BGEVDIR
 
-	runcommand "BACKGROUND" $SIMC sim.log 5
-	mv -f syswatch.log simwatch.log
-	echo "Doing ls on background folder" >> sim.log
-	ls -altr >> sim.log
+        runcommand "BACKGROUND" $SIMC sim.log 5
+        mv -f syswatch.log simwatch.log
+        echo "Doing ls on background folder" >> sim.log
+        ls -altr >> sim.log
 	
-	cd ..
-
-	export CONFIG_GENERATOR=$SAVE_CONFIG_GENERATOR
-	export CONFIG_NEVENTS=$SAVE_CONFIG_NEVENTS
-	export CONFIG_SIMULATION="EmbedSig"
+        cd ..
+        export CONFIG_GENERATOR=$SAVE_CONFIG_GENERATOR
+        export CONFIG_NEVENTS=$SAVE_CONFIG_NEVENTS
+        export CONFIG_SIMULATION="EmbedSig"
 	
     fi
 
     if [[ $CONFIG_SELEVMACRO != "" ]]; then
-	# case in which we use a trigger macro to select events after generation+propagation
-	jtry=0
-	while true
-	do
-	    echo "TRIAL" $jtry
-	    runcommand "SIMULATION" $GENC sim.log 5
-	    mv -f syswatch.log simwatch.log
+        # case in which we use a trigger macro to select events after generation+propagation
+        jtry=0
+        while true
+        do
+            echo "TRIAL" $jtry
+            runcommand "SIMULATION" $GENC sim.log 5
+            mv -f syswatch.log simwatch.log
 
 
-	    echo -e "\n"
-	    echo -e "\n" >&2
+            echo -e "\n"
+            echo -e "\n" >&2
 
-	    echo "* EVENT SELECTION : $CONFIG_SELEVMACRO"
-	    echo "* EVENT SELECTION : output log in tag.log"
-	    echo "* EVENT SELECTION : $CONFIG_SELEVMACRO" >&2
-	    echo "* EVENT SELECTION : output log in tag.log" >&2
+            echo "* EVENT SELECTION : $CONFIG_SELEVMACRO"
+            echo "* EVENT SELECTION : output log in tag.log"
+            echo "* EVENT SELECTION : $CONFIG_SELEVMACRO" >&2
+            echo "* EVENT SELECTION : output log in tag.log" >&2
 	    
-	    aliroot -b -q -x ${CONFIG_SELEVMACRO}+ > tag.log 2>&1
-	    exitcode=$?
-	    isthere="$(grep "FOUND IN KINE TREE" tag.log)"
-	    echo $isthere
-	    echo "exitcode" $exitcode
-	    if [ $exitcode -eq 0 ]; then
-		echo "Requested particle found -> run digitization"
-		break
-	    else
-		echo "Requested particle not found -> generate another event"
-		rm *.Hits.root galice.root Kinematics.root TrackRefs.root geometry.root sim.log
-		jtry=$((jtry+1))
+            aliroot -b -q -x ${CONFIG_SELEVMACRO}+ > tag.log 2>&1
+            exitcode=$?
+            isthere="$(grep "FOUND IN KINE TREE" tag.log)"
+            echo $isthere
+            echo "exitcode" $exitcode
+            if [ $exitcode -eq 0 ]; then
+                echo "Requested particle found -> run digitization"
+                break
+            else
+                echo "Requested particle not found -> generate another event"
+                rm *.Hits.root galice.root Kinematics.root TrackRefs.root geometry.root sim.log
+                jtry=$((jtry+1))
                 CONFIG_SEED=($(awk -v ranseed=$CONFIG_SEED 'BEGIN {
-                                   srand(ranseed)
-                                   k=rand()
-                                   print int(1 + k * 10000000)
-                                   }'))
-		echo "New seed" $CONFIG_SEED
-	    fi
-	done
+                               srand(ranseed)
+                               k=rand()
+                               print int(1 + k * 10000000)
+                               }'))
+                echo "New seed" $CONFIG_SEED
+            fi
+        done
 	
-	runcommand "DIGITIZATION" $DIGC dig.log 5
-	mv -f syswatch.log digwatch.log
+        runcommand "DIGITIZATION" $DIGC dig.log 5
+        mv -f syswatch.log digwatch.log
 	
     else
-	runcommand "SIMULATION" $SIMC sim.log 5
-	mv -f syswatch.log simwatch.log
+        runcommand "SIMULATION" $SIMC sim.log 5
+        mv -f syswatch.log simwatch.log
     fi
     
     runBenchmark

--- a/MC/sim.C
+++ b/MC/sim.C
@@ -58,6 +58,14 @@ void sim()
   gROOT->LoadMacro("$ALIDPG_ROOT/MC/Config_LoadLibraries.C");
   gROOT->ProcessLine("Config_LoadLibraries();");
   AliSimulation sim(config_macro.Data());
+  
+  if (gSystem->Getenv("CONFIG_DETECTOR")) {
+    if (strcmp(gSystem->Getenv("CONFIG_DETECTOR"), "FOCAL") == 0) {
+      printf(">>>>> sim.C: No align data from CDB when running FOCAL !!!!!!!!!!!!!!! \n");  
+      sim.SetLoadAlignFromCDB(kFALSE);
+      sim.SetUseDetectorsFromGRP(kFALSE);
+    }
+  }
 
   /* configuration */
   SimulationConfig(sim, simulationConfig);


### PR DESCRIPTION
Files touched:
1 MC/dpgsim.sh
1.1  Support for the "--detector FOCAL" option,  which enables a special list of detector (see DetConfig.C)
1.2 Added the option "--focalGeometryFile <filename>" to be able to switch easily between different geometries
1.3 Only the "sim" mode is available for FOCAL simulations with these changes. No FOCAL digitization yet!!

2 MC/Config_LoadLibraries.C
   Load the FOCAL libraries from the FOCAL external package if "--detector FOCAL" option is present

3 MC/DetectorConfig.C
3.1  Implemented an EDetector_t option for FOCAL and enabled/disabled needed detectors.
3.2  In DetectorInit(), run the AliPIPEFOCAL and FOCAL constructors for FOCAL simulations

4 MC/sim.C
  Switch off LoadAlignFromCDB() and UseDetectorsFromGRP() for the FOCAL case, since there is no FOCAL alignment entry in the CDB yet.

5) Added MC/CustomGenerators/Upgrade/FOCAL_Generators.C 
  This contains several tailored generators for FOCAL simulations