### PR TITLE
[ALIROOT-8678] Set weight power to 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.so
 *.pcm
 *.log
+.vscode

--- a/MC/CustomGenerators/PWGGA/Pythia8Weighted_GammaTriggerAndJet.C
+++ b/MC/CustomGenerators/PWGGA/Pythia8Weighted_GammaTriggerAndJet.C
@@ -68,7 +68,7 @@ GeneratorCustom
   }
   
   // Set the desired weight
-  ((AliGenPythiaPlus*) gener)->SetWeightPower(6.);
+  ((AliGenPythiaPlus*) gener)->SetWeightPower(4.);
   
   return gener;
 }


### PR DESCRIPTION
Test productions for pp 13 TeV show that the weight power
6 is too high and biases the spectrum too much towards high
pt, reducing the statistics at low pt. As the goal of a weighted
production is to have the spectrum as flat in pt-hard as possible
the weight needs to be reduced. Setting weight power to 4
based on PYTHIA8 tutorial main08.cc.