### PR TITLE
Few changes, needed for FOCAL simulations

### DIFF
--- a/MC/CustomGenerators/Upgrade/FOCAL_Generators.C
+++ b/MC/CustomGenerators/Upgrade/FOCAL_Generators.C
@@ -4,97 +4,207 @@ Double_t EtaToTheta(Double_t eta)
 }
 
 // Generators for FOCAL simulations
-enum GenTypes : Int_t {
-    gun=0, 
-    box, 
-    pythia, 
-    pythia_MBtrig, 
-    pythia_dirgamma_trig, 
-    ntuple, 
-    hijing, 
-    hijingAP, 
-    PA_cocktail_dirgam, 
-    PA_cocktail_MBtrig, 
-    PA_cocktail_EPOS_MBtrig, 
-    PA_cocktail_EPOS_dirgam,
-    kNGenTypes
+enum GenTypes {
+  gun=0, 
+  gunJpsi,
+  box, 
+  pythia, 
+  pythia_MBtrig, 
+  pythia_dirgamma_trig, 
+  ntuple, 
+  hijing, 
+  hijingAP, 
+  PA_cocktail_dirgam, 
+  PA_cocktail_MBtrig, 
+  PA_cocktail_EPOS_MBtrig, 
+  PA_cocktail_EPOS_dirgam,
+  kNGenTypes
 };
 
 TString gGenTypeNames[kNGenTypes] = {
-    "gun", 
-    "box", 
-    "pythia", 
-    "pythia_MBtrig", 
-    "pythia_dirgamma_trig",
-    "ntuple",
-    "hijing",
-    "hijingAP",
-    "PA_cocktail_dirgam",
-    "PA_cocktail_MBtrig",
-    "PA_cocktail_EPOS_MBtrig",
-    "PA_cocktail_EPOS_dirgam"
+  "gun", 
+  "gunJpsi",
+  "box", 
+  "pythia", 
+  "pythia_MBtrig", 
+  "pythia_dirgamma_trig",
+  "ntuple",
+  "hijing",
+  "hijingAP",
+  "PA_cocktail_dirgam",
+  "PA_cocktail_MBtrig",
+  "PA_cocktail_EPOS_MBtrig",
+  "PA_cocktail_EPOS_dirgam"
 };
 
-Int_t gNtracks = 1;
 
 AliGenerator* GeneratorCustom(TString opt = "") {
-
+        
   Int_t generatorType = gun;
-  
-  for (Int_t iopt = 0; iopt < kNGenTypes; iopt++)
-    if (opt.EqualTo(gGenTypeNames[iopt]))
+  for (Int_t iopt = 0; iopt < kNGenTypes; iopt++) {
+    if (opt.EqualTo(gGenTypeNames[iopt])) {
       generatorType = iopt;
+    }
+  }
     
   //switch between the different generators
   AliGenerator * generator = 0x0;
   switch(generatorType) {
+          
     case gun:
     // Example for Fixed Particle Gun             
     {
-      AliGenFixed *gener = new AliGenFixed(gNtracks);
-	  gener->SetMomentum(500.);
-	  gener->SetPhi(0.);
-	  //gener->SetTheta(0.0556*180./TMath::Pi());   // to hit FOCAL at 20cm from beam axis at Z=360cm
-	  gener->SetTheta(EtaToTheta(4.5));
-	  gener->SetOrigin(0,0,0);        //vertex position
-	  gener->SetPart(kGamma);
-	  //gener->SetPart(kPiPlus);
-	  generator = gener;
+      float pmom = 500.0; // GeV/c      
+      if (gSystem->Getenv("CONFIG_PMOM")) {
+        pmom = atof(gSystem->Getenv("CONFIG_PMOM"));
+      }
+      
+      float eta = 4.5;
+      if (gSystem->Getenv("CONFIG_ETA")) {
+        eta = atof(gSystem->Getenv("CONFIG_ETA"));
+      }
+      
+      int pdg = kGamma;
+      if (gSystem->Getenv("CONFIG_PDG")) {
+        pdg = atoi(gSystem->Getenv("CONFIG_PDG"));
+      }
+            
+      AliGenFixed *gener = new AliGenFixed(1);
+      gener->SetMomentum(pmom);
+      gener->SetPhi(0.);
+      gener->SetTheta(EtaToTheta(eta));
+      gener->SetOrigin(0,0,0);        //vertex position
+      gener->SetPart(pdg);
+      generator = gener;
     }
     break;
 
+    case gunJpsi:
+    {
+      float ptmin = 0.0;      
+      if (gSystem->Getenv("CONFIG_PTMIN")) {
+        ptmin = atof(gSystem->Getenv("CONFIG_PTMIN"));
+      }
+      float ptmax = 10.0;      
+      if (gSystem->Getenv("CONFIG_PTMAX")) {
+        ptmax = atof(gSystem->Getenv("CONFIG_PTMAX"));
+      }
+      float ymin = 3.0;      
+      if (gSystem->Getenv("CONFIG_YMIN")) {
+        ymin = atof(gSystem->Getenv("CONFIG_YMIN"));
+      }
+      float ymax = 6.0;      
+      if (gSystem->Getenv("CONFIG_YMAX")) {
+        ymax = atof(gSystem->Getenv("CONFIG_YMAX"));
+      }
+      float phimin = 0.0;      
+      if (gSystem->Getenv("CONFIG_PHIMIN")) {
+        phimin = atof(gSystem->Getenv("CONFIG_PHIMIN"));
+      }
+      float phimax = 360.0;      
+      if (gSystem->Getenv("CONFIG_PHIMAX")) {
+        phimax = atof(gSystem->Getenv("CONFIG_PHIMAX"));
+      }
+            
+      // load libraries to use Evtgen
+      gSystem->Load("libPhotos");
+      //gSystem->Load("libEvtGenBase");
+      //gSystem->Load("libEvtGenModels");
+      gSystem->Load("libEvtGen");
+      gSystem->Load("libEvtGenExternal");
+      gSystem->Load("libTEvtGen");  
+      //
+      // set external decayer
+      TVirtualMCDecayer* decayer = new AliDecayerPythia();
+      decayer->SetForceDecay(kAll);
+      decayer->Init();
+      gMC->SetExternalDecayer(decayer);      
+            
+      AliGenCocktail *gener = new AliGenCocktail();
+      gener->UsePerEventRates();
+      // flat low pT
+      AliGenParam *jpsi = new AliGenParam(1, AliGenMUONlib::kJpsi, "Flat", "Jpsi");  // flat pt distribution
+      jpsi->SetPtRange(ptmin, ptmax);
+      jpsi->SetYRange(ymin, ymax);
+      jpsi->SetPhiRange(phimin, phimax);
+      jpsi->SetForceDecay(kNoDecay);
+      
+      gener->AddGenerator(jpsi, "jpsi", 1.0);
+      
+      AliGenEvtGen *gene = new AliGenEvtGen();
+      gene->SetForceDecay(kBJpsiDiElectron);
+      gene->SetParticleSwitchedOff(AliGenEvtGen::kCharmPart);
+      gener->AddGenerator(gene, "EvtGen", 1.);
+      
+      generator = gener;
+    }
+    break;
+    
     case box:  
     // Example for Moving Particle Gun  
     {
-      AliGenBox *gener = new AliGenBox(gNtracks);
-	  //gener->SetMomentumRange(49.999,50.001);
-	  gener->SetPtRange(0.,20.);
-	  gener->SetPhiRange(0.,360.);  // full polar angle around beam axis
-	  gener->SetEtaRange(3.5, 5.8);
-	  gener->SetOrigin(0,0,0);   
-	  //vertex position
-	  gener->SetSigma(0,0,0);         //Sigma in (X,Y,Z) (cm) on IP position
-	  gener->SetPart(kPi0);
-	  generator = gener;
+      float ptmin = 0.0;      
+      if (gSystem->Getenv("CONFIG_PTMIN")) {
+        ptmin = atof(gSystem->Getenv("CONFIG_PTMIN"));
+      }
+      float ptmax = 10.0;      
+      if (gSystem->Getenv("CONFIG_PTMAX")) {
+        ptmax = atof(gSystem->Getenv("CONFIG_PTMAX"));
+      }
+      float etamin = 3.0;      
+      if (gSystem->Getenv("CONFIG_ETAMIN")) {
+        etamin = atof(gSystem->Getenv("CONFIG_ETAMIN"));
+      }
+      float etamax = 6.0;      
+      if (gSystem->Getenv("CONFIG_ETAMAX")) {
+        etamax = atof(gSystem->Getenv("CONFIG_ETAMAX"));
+      }
+      float phimin = 0.0;      
+      if (gSystem->Getenv("CONFIG_PHIMIN")) {
+        phimin = atof(gSystem->Getenv("CONFIG_PHIMIN"));
+      }
+      float phimax = 360.0;      
+      if (gSystem->Getenv("CONFIG_PHIMAX")) {
+        phimax = atof(gSystem->Getenv("CONFIG_PHIMAX"));
+      }
+      int pdg = kGamma;
+      if (gSystem->Getenv("CONFIG_PDG")) {
+        pdg = atoi(gSystem->Getenv("CONFIG_PDG"));
+      }
+            
+      AliGenBox *gener = new AliGenBox(1);
+      gener->SetPtRange(ptmin, ptmax);
+      gener->SetPhiRange(phimin, phimax);  // full polar angle around beam axis
+      gener->SetEtaRange(etamin, etamax);
+      gener->SetOrigin(0,0,0);   
+      //vertex position
+      gener->SetSigma(0,0,0);         //Sigma in (X,Y,Z) (cm) on IP position
+      gener->SetPart(pdg);
+      generator = gener;
     }
     break;
 
     case pythia:
     // Example for Pythia            
     {
-	  AliGenPythia *gener = new AliGenPythia(-1); 
-	  gener->SetMomentumRange(0,999999); 
-	  gener->SetThetaRange(0., 45.); 
-	  gener->SetYRange(-12,12); 
-	  gener->SetPtRange(0,1000); 
-	  gener->SetProcess(kPyMb); // Min. bias events 
-	  gener->SetEnergyCMS(14000.); // LHC energy 
-	  //gener->SetOrigin(0, 0, 0); // Vertex position 
-	  gener->SetSigma(0, 0, 5.3); // Sigma in (X,Y,Z) (cm) on IP position 
-	  gener->SetCutVertexZ(1.); // Truncate at 1 sigma 
-	  gener->SetVertexSmear(kPerEvent); // Smear per event 
-	  gener->SetTrackingFlag(1); // Particle transport 
-	  generator = gener;
+      float energy = 14000;  // GeV
+      if (gSystem->Getenv("CONFIG_ENERGY")) {
+        energy = atof(gSystem->Getenv("CONFIG_ENERGY"));
+      }
+            
+      AliGenPythia *gener = new AliGenPythia(-1); 
+      gener->SetMomentumRange(0,999999); 
+      gener->SetThetaRange(0., 45.); 
+      gener->SetYRange(-12,12); 
+      gener->SetPtRange(0,1000); 
+      gener->SetProcess(kPyMb); // Min. bias events 
+      gener->SetEnergyCMS(energy); // LHC energy 
+      //gener->SetOrigin(0, 0, 0); // Vertex position 
+      gener->SetSigma(0, 0, 5.3); // Sigma in (X,Y,Z) (cm) on IP position 
+      gener->SetCutVertexZ(1.); // Truncate at 1 sigma 
+      gener->SetVertexSmear(kPerEvent); // Smear per event 
+      gener->SetTrackingFlag(1); // Particle transport 
+      generator = gener;
     }
     break;
 
@@ -102,25 +212,30 @@ AliGenerator* GeneratorCustom(TString opt = "") {
     case pythia_dirgamma_trig:
     // Example for Pythia            
     {
+      float energy = 14000;  // GeV
+      if (gSystem->Getenv("CONFIG_ENERGY")) {
+        energy = atof(gSystem->Getenv("CONFIG_ENERGY"));
+      }      
+            
       AliGenPythiaFOCAL *gener = new AliGenPythiaFOCAL(-1); 
-	  gener->SetMomentumRange(0,999999); 
-	  gener->SetThetaRange(0., 45.); 
-	  gener->SetYRange(-12,12); 
-	  gener->SetPtRange(0,1000); 
-	  gener->SetEnergyCMS(14000.); // LHC energy 
-	  //gener->SetOrigin(0, 0, 0); // Vertex position 
-	  gener->SetSigma(0, 0, 5.3); // Sigma in (X,Y,Z) (cm) on IP position 
-	  gener->SetCutVertexZ(1.); // Truncate at 1 sigma 
-	  gener->SetVertexSmear(kPerEvent); // Smear per event 
-	  gener->SetTrackingFlag(1); // Particle transport 
+      gener->SetMomentumRange(0,999999); 
+      gener->SetThetaRange(0., 45.); 
+      gener->SetYRange(-12,12); 
+      gener->SetPtRange(0,1000); 
+      gener->SetEnergyCMS(energy); // LHC energy 
+      //gener->SetOrigin(0, 0, 0); // Vertex position 
+      gener->SetSigma(0, 0, 5.3); // Sigma in (X,Y,Z) (cm) on IP position 
+      gener->SetCutVertexZ(1.); // Truncate at 1 sigma 
+      gener->SetVertexSmear(kPerEvent); // Smear per event 
+      gener->SetTrackingFlag(1); // Particle transport 
       //gener->SetEtaInFOCAL(kTRUE);
       //gener->SetPi0InFOCAL(kTRUE);
       if (generatorType == pythia_MBtrig) {
-	    gener->SetProcess(kPyMb); // Min. bias events 
+        gener->SetProcess(kPyMb); // Min. bias events 
         gener->SetDecayPhotonInFOCAL(kTRUE);
       }
       else {
-	    gener->SetProcess(kPyDirectGamma);
+        gener->SetProcess(kPyDirectGamma);
         gener->SetFragPhotonInFOCAL(kTRUE);
       }
       gener->SetCheckFOCAL(kTRUE);  
@@ -133,22 +248,27 @@ AliGenerator* GeneratorCustom(TString opt = "") {
     case ntuple:
     // Example for reading from a external file             *
     {
-  	  AliGenExtFile *gener = new AliGenExtFile(-1); 
-	  //gener->SetVertexSmear(kPerEvent); 
-	  gener->SetTrackingFlag(1);
-	
-	  AliGenReaderTreeK * reader = new AliGenReaderTreeK();
-	  reader->SetFileName("sim1/galice.root");
-	  gener->SetReader(reader);
-	  generator = gener;
+      AliGenExtFile *gener = new AliGenExtFile(-1); 
+      //gener->SetVertexSmear(kPerEvent); 
+      gener->SetTrackingFlag(1);
+
+      AliGenReaderTreeK * reader = new AliGenReaderTreeK();
+      reader->SetFileName("sim1/galice.root");
+      gener->SetReader(reader);
+      generator = gener;
     }
     break;
 
     case hijing:
     // Example for reading from a external file             *
     {
-      AliGenHijing *gener = new AliGenHijing(-1); 
-      gener->SetEnergyCMS(5500.); // center of mass energy 
+      AliGenHijing *gener = new AliGenHijing(-1);
+      // Take collision energy from command line params if specified
+      float energy = 5500.0;
+      if (gSystem->Getenv("CONFIG_ENERGY")) {
+        energy = atof(gSystem->Getenv("CONFIG_ENERGY"));
+      }
+      gener->SetEnergyCMS(energy); // center of mass energy 
       gener->SetReferenceFrame("CMS"); // reference frame 
       gener->SetProjectile("A", 208, 82); // projectile 
       gener->SetTarget ("A", 208, 82); // projectile 
@@ -166,7 +286,13 @@ AliGenerator* GeneratorCustom(TString opt = "") {
     case hijingAP:
     {
       AliGenHijingFOCAL *gener = new AliGenHijingFOCAL(); 
-      gener->SetEnergyCMS(8790.); // center of mass energy 
+      // Take collision energy from command line params if specified
+      float energy = 8790.0;
+      if (gSystem->Getenv("CONFIG_ENERGY")) {
+        energy = atof(gSystem->Getenv("CONFIG_ENERGY"));
+      }
+      
+      gener->SetEnergyCMS(energy); // center of mass energy 
       gener->SetReferenceFrame("CMS"); // reference frame 
       gener->SetBoostLHC(0.0);   // No boost for now; need to check sign
       gener->SetProjectile("A", 208, 82); // projectile proton
@@ -193,10 +319,16 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       AliGenCocktail *cocktail = new AliGenCocktail();
       cocktail->SetOrigin(0, 0, 0); // Vertex position
       cocktail->SetSigma(0, 0, 5.8); // Sigma in (X,Y,Z) (cm) on IP position
-	  cocktail->SetVertexSmear(kPerEvent); // Smear per event
+      cocktail->SetVertexSmear(kPerEvent); // Smear per event
 
       AliGenHijing *hijing = new AliGenHijing(-1); 
-      hijing->SetEnergyCMS(8790.); // center of mass energy 
+      // Take collision energy from command line params if specified
+      float energy = 8790.0;
+      if (gSystem->Getenv("CONFIG_ENERGY")) {
+        energy = atof(gSystem->Getenv("CONFIG_ENERGY"));
+      }
+      
+      hijing->SetEnergyCMS(energy); // center of mass energy 
       hijing->SetReferenceFrame("CMS"); // reference frame 
       hijing->SetBoostLHC(0.0);   // No boost for now; need to check sign
       hijing->SetProjectile("A", 208, 82); // projectile proton
@@ -212,19 +344,19 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       cocktail->AddGenerator(hijing,"Hijing",1.);
 
       AliGenPythiaFOCAL *pythia = new AliGenPythiaFOCAL(-1);
-	  pythia->SetMomentumRange(0,999999);
+      pythia->SetMomentumRange(0,999999);
       pythia->SetThetaRange(0., 45.);
       pythia->SetYRange(-12,12);
-	  pythia->SetPtRange(0,1000);
-	  pythia->SetEnergyCMS(8790.); // LHC energy
-	  pythia->SetTrackingFlag(1); // Particle transport
+      pythia->SetPtRange(0,1000);
+      pythia->SetEnergyCMS(energy); // LHC energy
+      pythia->SetTrackingFlag(1); // Particle transport
       if (generatorType == PA_cocktail_dirgam) {
         pythia->SetProcess(kPyDirectGamma); // Direct photon events
-	    pythia->SetFragPhotonInFOCAL(kTRUE);
+        pythia->SetFragPhotonInFOCAL(kTRUE);
       }
       else {
         pythia->SetProcess(kPyMb); // MB events
-	    pythia->SetDecayPhotonInFOCAL(kTRUE);
+        pythia->SetDecayPhotonInFOCAL(kTRUE);
       }
       pythia->SetCheckFOCAL(kTRUE);
       pythia->SetFOCALEta(3.5, 5.9);
@@ -238,15 +370,46 @@ AliGenerator* GeneratorCustom(TString opt = "") {
     case PA_cocktail_EPOS_dirgam:
     case PA_cocktail_EPOS_MBtrig:
     {
+      // Take collision energy from command line params if specified
+      float energy = 8790.0;
+      if (gSystem->Getenv("CONFIG_ENERGY")) {
+        energy = atof(gSystem->Getenv("CONFIG_ENERGY"));
+      }
+      int nEvents = 1;
+      if (gSystem->Getenv("CONFIG_NEVENTS")) {
+        nEvents = atoi(gSystem->Getenv("CONFIG_NEVENTS"));
+      }
+      int projectileId = 2212;            // proton
+      int targetId = 82*10000 + 208*10;   // Pb nucleus in the EPOS language
+      float projectileEnergy = 0.5 * energy * TMath::Sqrt(208./82.);
+      float targetEnergy = 0.5 * energy * TMath::Sqrt(82./208.);
+      bool pileup = false;
+      
       AliGenCocktailFOCAL *cocktail = new AliGenCocktailFOCAL();
       cocktail->SetOrigin(0, 0, 0); // Vertex position
       cocktail->SetSigma(0, 0, 5.8); // Sigma in (X,Y,Z) (cm) on IP position
       cocktail->SetVertexSmear(kPerEvent); // Smear per event
 
-      TString fifoname("$TMPDIR/myfifo");
+      /*TString fifoname("$TMPDIR/myfifo");
       AliGenExtExec* eposExt = new AliGenExtExec();
       eposExt->SetPathScript(Form("./gen_eposlhc.sh %s",fifoname.Data()));
       eposExt->SetPathFIFO(fifoname);
+      cocktail->AddGenerator(eposExt,"EPOS",1.);*/
+      
+      TString fifoname("myfifo");
+      gROOT->ProcessLine(Form(".! rm -rf %s", fifoname.Data()));
+      gROOT->ProcessLine(Form(".! mkfifo %s", fifoname.Data()));
+      gROOT->ProcessLine(Form(".! bash $ALIDPG_ROOT/MC/EXTRA/gen_eposlhc.sh %s %d %d %f %d %f &> gen_eposlhc%d.log &",
+                              fifoname.Data(), nEvents,
+                              projectileId, projectileEnergy,
+                              targetId, targetEnergy, pileup));
+  
+      // connect HepMC reader
+      AliGenReaderHepMC *reader = new AliGenReaderHepMC();
+      reader->SetFileName(fifoname.Data());
+      AliGenExtFile *eposExt = new AliGenExtFile(-1);
+      eposExt->SetName("EPOSLHC");
+      eposExt->SetReader(reader);
       cocktail->AddGenerator(eposExt,"EPOS",1.);
 
       AliGenPythiaFOCAL *pythia = new AliGenPythiaFOCAL(-1);
@@ -254,14 +417,14 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       pythia->SetThetaRange(0., 45.);
       pythia->SetYRange(-12,12);
       pythia->SetPtRange(0,1000);
-      pythia->SetEnergyCMS(8790.); // LHC energy
+      pythia->SetEnergyCMS(energy); // LHC energy
       pythia->SetTrackingFlag(1); // Particle transport
       if (generatorType == PA_cocktail_EPOS_dirgam) {
         pythia->SetProcess(kPyDirectGamma); // Direct photon events
         pythia->SetFragPhotonInFOCAL(kTRUE);
-	    pythia->SetCheckFOCAL(kTRUE);
-	    pythia->SetFOCALEta(3.5, 5.9);
-	    pythia->SetTriggerParticleMinPt(4.0);
+        pythia->SetCheckFOCAL(kTRUE);
+        pythia->SetFOCALEta(3.5, 5.9);
+        pythia->SetTriggerParticleMinPt(4.0);
       } else {
         pythia->SetProcess(kPyMb); // MB events
         //pythia->SetDecayPhotonInFOCAL(kTRUE);

--- a/MC/CustomGenerators/Upgrade/FOCAL_Generators.C
+++ b/MC/CustomGenerators/Upgrade/FOCAL_Generators.C
@@ -7,7 +7,8 @@ Double_t EtaToTheta(Double_t eta)
 enum GenTypes {
   gun=0, 
   gunJpsi,
-  box, 
+  box,
+  boxWithDecay,
   pythia, 
   pythia_MBtrig, 
   pythia_dirgamma_trig, 
@@ -25,6 +26,7 @@ TString gGenTypeNames[kNGenTypes] = {
   "gun", 
   "gunJpsi",
   "box", 
+  "boxWithDecay",
   "pythia", 
   "pythia_MBtrig", 
   "pythia_dirgamma_trig",
@@ -183,6 +185,82 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       generator = gener;
     }
     break;
+    
+    case boxWithDecay:  
+    // Example for Moving Particle Gun (with decays enabled) 
+    {
+      float ptmin = 0.0;      
+      if (gSystem->Getenv("CONFIG_PTMIN")) {
+        ptmin = atof(gSystem->Getenv("CONFIG_PTMIN"));
+      }
+      float ptmax = 10.0;      
+      if (gSystem->Getenv("CONFIG_PTMAX")) {
+        ptmax = atof(gSystem->Getenv("CONFIG_PTMAX"));
+      }
+      float ymin = 3.0;      
+      if (gSystem->Getenv("CONFIG_YMIN")) {
+        ymin = atof(gSystem->Getenv("CONFIG_YMIN"));
+      }
+      float ymax = 6.0;      
+      if (gSystem->Getenv("CONFIG_YMAX")) {
+        ymax = atof(gSystem->Getenv("CONFIG_YMAX"));
+      }
+      float phimin = 0.0;      
+      if (gSystem->Getenv("CONFIG_PHIMIN")) {
+        phimin = atof(gSystem->Getenv("CONFIG_PHIMIN"));
+      }
+      float phimax = 360.0;      
+      if (gSystem->Getenv("CONFIG_PHIMAX")) {
+        phimax = atof(gSystem->Getenv("CONFIG_PHIMAX"));
+      }
+      int pdg = 23;   // default: Z0
+      if (gSystem->Getenv("CONFIG_PDG")) {
+        pdg = atoi(gSystem->Getenv("CONFIG_PDG"));
+      }
+      
+      // set external decayer
+      TVirtualMCDecayer* decayer = new AliDecayerPythia();
+      decayer->SetForceDecay(kAll);
+      decayer->Init();
+      gMC->SetExternalDecayer(decayer);      
+      
+      AliGenCocktail *gener = new AliGenCocktail();
+      gener->UsePerEventRates();
+      
+      AliGenBox *genBox = new AliGenBox(1);
+      genBox->SetPtRange(ptmin, ptmax);
+      genBox->SetPhiRange(phimin, phimax);  // full polar angle around beam axis
+      genBox->SetYRange(ymin, ymax);
+      genBox->SetOrigin(0,0,0);   
+      //vertex position
+      genBox->SetSigma(0,0,0);         //Sigma in (X,Y,Z) (cm) on IP position
+      genBox->SetPart(pdg);
+      gener->AddGenerator(genBox, "box", 1.);      
+      
+      AliGenEvtGen *gene = new AliGenEvtGen();
+      // NOTE: the original decay table is in AliRoot/TEvtGen/EvtGen/DecayTable/DIELECTRON.DEC
+      //       If the decay you are after is there, then you can comment out the following line.
+      //       Alternatively, make sure the decay file you use below is in the working directory (or copied to 
+      //         the grid working note if you run on the grid)
+      gene->SetUserDecayTable("DIELECTRON.DEC");
+      if (pdg==23) {
+        gene->SetForceDecay(kZDiElectron);
+        gene->SetParticleSwitchedOff(AliGenEvtGen::kAllPart);
+      }
+      if (pdg==443) {
+        gene->SetForceDecay(kDiElectron);
+        gene->SetParticleSwitchedOff(AliGenEvtGen::kCharmPart);      
+      }
+      if (pdg==553) {
+        gene->SetForceDecay(kDiElectron);
+        gene->SetParticleSwitchedOff(AliGenEvtGen::kCharmPart);      
+      }
+      gene->Init();
+      gener->AddGenerator(gene, "EvtGen", 1.);
+      
+      generator = gener;
+    }
+    break;
 
     case pythia:
     // Example for Pythia            
@@ -194,7 +272,7 @@ AliGenerator* GeneratorCustom(TString opt = "") {
             
       AliGenPythia *gener = new AliGenPythia(-1); 
       gener->SetMomentumRange(0,999999); 
-      gener->SetThetaRange(0., 45.); 
+      //gener->SetThetaRange(0., 45.); 
       gener->SetYRange(-12,12); 
       gener->SetPtRange(0,1000); 
       gener->SetProcess(kPyMb); // Min. bias events 
@@ -240,7 +318,11 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       }
       gener->SetCheckFOCAL(kTRUE);  
       gener->SetFOCALEta(3.5, 6.2);
-      gener->SetTriggerParticleMinPt(4.0);
+      float ptmin = 4.0;      
+      if (gSystem->Getenv("CONFIG_PTMIN")) {
+        ptmin = atof(gSystem->Getenv("CONFIG_PTMIN"));
+      }
+      gener->SetTriggerParticleMinPt(ptmin);
       generator = gener;
     }
     break;
@@ -304,7 +386,7 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       gener->SetSpectators(0); // Don't track spectators 
       gener->SetSelectAll(0); // kinematic selection 
       gener->SetImpactParameterRange(0., 8.); // Impact parameter range (fm) 
-      //gener->UnsetDataDrivenSpectators();
+      gener->UnsetDataDrivenSpectators();
 
       gener->SetTrigger(2); // 2: direct photons; 3: decay photons
       gener->SetPtJet(4.);
@@ -390,20 +472,26 @@ AliGenerator* GeneratorCustom(TString opt = "") {
       cocktail->SetSigma(0, 0, 5.8); // Sigma in (X,Y,Z) (cm) on IP position
       cocktail->SetVertexSmear(kPerEvent); // Smear per event
 
-      /*TString fifoname("$TMPDIR/myfifo");
+      /*TString fifoname("myfifo");
       AliGenExtExec* eposExt = new AliGenExtExec();
-      eposExt->SetPathScript(Form("./gen_eposlhc.sh %s",fifoname.Data()));
+      //eposExt->SetPathScript(Form("./gen_eposlhc.sh %s",fifoname.Data()));
+      eposExt->SetPathScript(Form("crmc -o hepmc -f %s -n %d -m 0 -i %d -p %f -I %d -P %f",
+                                  fifoname.Data(),nEvents,projectileId,projectileEnergy,targetId,targetEnergy));
       eposExt->SetPathFIFO(fifoname);
       cocktail->AddGenerator(eposExt,"EPOS",1.);*/
       
       TString fifoname("myfifo");
       gROOT->ProcessLine(Form(".! rm -rf %s", fifoname.Data()));
       gROOT->ProcessLine(Form(".! mkfifo %s", fifoname.Data()));
-      gROOT->ProcessLine(Form(".! bash $ALIDPG_ROOT/MC/EXTRA/gen_eposlhc.sh %s %d %d %f %d %f &> gen_eposlhc%d.log &",
+      /*gROOT->ProcessLine(Form(".! bash $ALIDPG_ROOT/MC/EXTRA/gen_eposlhc.sh %s %d %d %f %d %f &> gen_eposlhc%d.log &",
                               fifoname.Data(), nEvents,
                               projectileId, projectileEnergy,
-                              targetId, targetEnergy, pileup));
-  
+                              targetId, targetEnergy, pileup));*/
+      gROOT->ProcessLine(Form(".! crmc -o hepmc -f %s -n %d -m 0 -i %d -p %f -I %d -P %f &> gen_eposlhc.log &",
+                              fifoname.Data(), nEvents,
+                              projectileId, projectileEnergy,
+                              targetId, targetEnergy));
+      
       // connect HepMC reader
       AliGenReaderHepMC *reader = new AliGenReaderHepMC();
       reader->SetFileName(fifoname.Data());

--- a/MC/DetectorConfig.C
+++ b/MC/DetectorConfig.C
@@ -16,6 +16,7 @@ enum EDetector_t {
   kDetectorCentralBarrelTracking,
   kDetectorRun3,
   kDetectorFOCAL,
+  kDetectorFOCALnoFIT,
   kDetectorCustom,
   kNDetectors
 };
@@ -28,6 +29,7 @@ const Char_t *DetectorName[kNDetectors] = {
   "CentralBarrelTracking",
   "Run3",
   "FOCAL",
+  "FOCALnoFIT",
   "Custom"
 };
 
@@ -157,7 +159,7 @@ DetectorConfig(Int_t tag)
 
   if( tag == kDetectorRun3 )
     DetectorInitRun3(tag);
-  else if (tag == kDetectorFOCAL) {
+  else if (tag == kDetectorFOCAL || tag == kDetectorFOCALnoFIT) {
     gROOT->ProcessLine(".x $ALIDPG_ROOT/MC/DetectorInitFOCAL.C");
   }
   else

--- a/MC/DetectorInitFOCAL.C
+++ b/MC/DetectorInitFOCAL.C
@@ -30,6 +30,10 @@ Special FOCAL simulations detector init
   Int_t iFIT    = 1;
   Int_t iFOCAL  = 1;
   
+  if (strcmp(gSystem->Getenv("CONFIG_DETECTOR"), "FOCALnoFIT") == 0) {
+    iFIT = 0;        
+  }
+  
   Int_t year = atoi(gSystem->Getenv("CONFIG_YEAR"));
 
   //=================== Alice BODY parameters =============================
@@ -258,6 +262,6 @@ Special FOCAL simulations detector init
   }
   
   if (iFIT) {
-    AliFIT *fit = new AliFITv8("FIT","FIT");
+    AliFIT *fit = new AliFITv9("FIT","FIT");
   }
 }

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -323,7 +323,7 @@ while [ ! -z "$1" ]; do
     elif [ "$option" = "--detector" ]; then
         CONFIG_DETECTOR="$1"
         # check that FOCAL env is set in case we run a FOCAL simulation
-        if [ "$CONFIG_DETECTOR" = "FOCAL" ]; then
+        if [ "$CONFIG_DETECTOR" = "FOCAL" ] || [ "$CONFIG_DETECTOR" = "FOCALnoFIT" ]; then
             if [ -z "$FOCAL" ]; then
                 echo "FOCAL simulation requested but FOCAL environment not set."
                 exit 1

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -39,6 +39,9 @@ function COMMAND_HELP(){
     echo "--ymin <min> --ymax <max>                 Rapidity range. Specific use may vary according to generator configuration"
     echo "--phimin <min> --phimax <max>             Azimuthal angle range (in degree). Specific use may vary according to generator configuration"
     echo "--ptmin <min> --ptmax <max>               Transverse momentum range. Specific use may vary according to generator configuration"
+    echo "--etamin <min> --etamax <max>             Eta range. Specific use may vary according to generator configuration"
+    echo "--pmom <momentum>                         Full momentum of generated particle. Specific use may vary according to generator configuration"
+    echo "--eta <eta>                               Eta of generated particle. Specific use may vary according to generator configuration"
     echo "--pthardmin <min> --pthardmax <max>       Range of pT hard bins (if applicable)" 
     echo "--pthardbin <bin number>                  For selection of predefined pT hard bins (see MC/dpgsim.sh for definition)"
     echo "--pttrigmin <min> --pttrigmax <max>       Range of pT for trigger particles (if applicable)"
@@ -65,7 +68,6 @@ function COMMAND_HELP(){
     echo "--keepTrackRefsFraction <percentage>      Percentage of subjobs that keeps the TrackRefs file"
     echo "--signalFilteringFraction <percentage>    Percentage of subjobs that use signal filtering (for embedding only)"
     echo "--material <densityFactor>                Modify material budget by a density factor"
-    echo "--its-material <densityFactor>            Modify its-only material budget following this syntaxt \"kSPDSiChip=1.2,kSPDSiSens=1.2,kSPDAlBus=1.2,kSPDCoolPipes=1.2,kSDDSiAll=1.12\""
     echo "--purifyKineOff                           Switch off the PurifyKine step in simulation" 
     echo "--fluka                                   Use FLUKA instead of GEANT3" 
     echo "--geant4                                  Use GEANT4 instead of GEANT3"
@@ -216,6 +218,10 @@ CONFIG_PHIMIN=""
 CONFIG_PHIMAX=""
 CONFIG_PTMIN=""
 CONFIG_PTMAX=""
+CONFIG_ETAMIN=""
+CONFIG_ETAMAX=""
+CONFIG_PMOM=""
+CONFIG_ETA=""
 CONFIG_PTHARDBIN=""
 CONFIG_PTHARDMIN=""
 CONFIG_PTHARDMAX=""
@@ -245,7 +251,6 @@ CONFIG_FASTB=""
 CONFIG_VDT="on"
 CONFIG_CLEANUP="on"
 CONFIG_MATERIAL=""
-CONFIG_ITS_MATERIAL=""
 CONFIG_KEEPTRACKREFSFRACTION="0"
 CONFIG_REMOVETRACKREFS="off"
 CONFIG_SIGNALFILTERINGFRACTION="100"
@@ -401,6 +406,22 @@ while [ ! -z "$1" ]; do
         CONFIG_PTMAX="$1"
 	export CONFIG_PTMAX
         shift
+    elif [ "$option" = "--etamin" ]; then
+        CONFIG_ETAMIN="$1"
+	export CONFIG_ETAMIN
+        shift    
+    elif [ "$option" = "--etamax" ]; then
+        CONFIG_ETAMAX="$1"
+	export CONFIG_ETAMAX
+        shift        
+    elif [ "$option" = "--pmom" ]; then
+        CONFIG_PMOM="$1"
+	export CONFIG_PMOM
+        shift    
+    elif [ "$option" = "--eta" ]; then
+        CONFIG_ETA="$1"
+	export CONFIG_ETA
+        shift    
     elif [ "$option" = "--pthardbin" ]; then
         CONFIG_PTHARDBIN="$1"
 	export CONFIG_PTHARDBIN
@@ -472,10 +493,6 @@ while [ ! -z "$1" ]; do
     elif [ "$option" = "--material" ]; then
         CONFIG_MATERIAL="$1"
 	export CONFIG_MATERIAL
-        shift
-    elif [ "$option" = "--its-material" ]; then
-        CONFIG_ITS_MATERIAL="$1"
-        export CONFIG_ITS_MATERIAL
         shift
     elif [ "$option" = "--geant4" ]; then
         CONFIG_GEANT4="on"
@@ -948,6 +965,10 @@ echo "phi-min (in deg.) $CONFIG_PHIMIN"
 echo "phi-max (in deg.) $CONFIG_PHIMAX"
 echo "pT-min........... $CONFIG_PTMIN"
 echo "pT-max........... $CONFIG_PTMAX"
+echo "pmom............. $CONFIG_PMOM"
+echo "eta.............. $CONFIG_ETA"
+echo "eta-min.......... $CONFIG_ETAMIN"
+echo "eta-max.......... $CONFIG_ETAMAX"
 echo "============================================"
 echo "pT-hard bin...... $CONFIG_PTHARDBIN"
 echo "pT-hard min...... $CONFIG_PTHARDMIN"

--- a/MC/dpgsim.sh
+++ b/MC/dpgsim.sh
@@ -68,6 +68,7 @@ function COMMAND_HELP(){
     echo "--keepTrackRefsFraction <percentage>      Percentage of subjobs that keeps the TrackRefs file"
     echo "--signalFilteringFraction <percentage>    Percentage of subjobs that use signal filtering (for embedding only)"
     echo "--material <densityFactor>                Modify material budget by a density factor"
+    echo "--its-material <densityFactor>            Modify its-only material budget following this syntaxt \"kSPDSiChip=1.2,kSPDSiSens=1.2,kSPDAlBus=1.2,kSPDCoolPipes=1.2,kSDDSiAll=1.12\""
     echo "--purifyKineOff                           Switch off the PurifyKine step in simulation" 
     echo "--fluka                                   Use FLUKA instead of GEANT3" 
     echo "--geant4                                  Use GEANT4 instead of GEANT3"
@@ -251,6 +252,7 @@ CONFIG_FASTB=""
 CONFIG_VDT="on"
 CONFIG_CLEANUP="on"
 CONFIG_MATERIAL=""
+CONFIG_ITS_MATERIAL=""
 CONFIG_KEEPTRACKREFSFRACTION="0"
 CONFIG_REMOVETRACKREFS="off"
 CONFIG_SIGNALFILTERINGFRACTION="100"
@@ -493,6 +495,10 @@ while [ ! -z "$1" ]; do
     elif [ "$option" = "--material" ]; then
         CONFIG_MATERIAL="$1"
 	export CONFIG_MATERIAL
+        shift
+    elif [ "$option" = "--its-material" ]; then
+        CONFIG_ITS_MATERIAL="$1"
+        export CONFIG_ITS_MATERIAL
         shift
     elif [ "$option" = "--geant4" ]; then
         CONFIG_GEANT4="on"

--- a/MC/sim.C
+++ b/MC/sim.C
@@ -60,7 +60,8 @@ void sim()
   AliSimulation sim(config_macro.Data());
   
   if (gSystem->Getenv("CONFIG_DETECTOR")) {
-    if (strcmp(gSystem->Getenv("CONFIG_DETECTOR"), "FOCAL") == 0) {
+    if ((strcmp(gSystem->Getenv("CONFIG_DETECTOR"), "FOCAL") == 0) ||
+        (strcmp(gSystem->Getenv("CONFIG_DETECTOR"), "FOCALnoFIT") == 0)) {
       printf(">>>>> sim.C: No align data from CDB when running FOCAL !!!!!!!!!!!!!!! \n");  
       sim.SetLoadAlignFromCDB(kFALSE);
       sim.SetUseDetectorsFromGRP(kFALSE);


### PR DESCRIPTION
1) Upgrade/FOCAL_Generators.C includes a new generator (boxWithDecay) which is a box generator for particles which require to be decayed (e.g. Z0, quarkonia). Also, there were many updates such that the generators capture the command line options and set the various kinematic options.
2) In the DetectorInitFOCAL.C we replaced FITv8 with FITv9
3) Added a new detector config "FOCALnoFIT", where we run the statndard detectors for FOCAL simulations, with the exception of FIT.
4) A few additional options were added in dpgsim.sh for eta ranges and full momentum