### PR TITLE
Update pt range of omega(2012)

### DIFF
--- a/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn003.C
+++ b/MC/CustomGenerators/PWGLF/Pythia8_Monash2013_Rsn003.C
@@ -16,8 +16,8 @@ AliGenerator* GeneratorCustom()
   // randomly injected particles
   const int nParticles = 2;
   particle_inj particleList[2] = { // {name,pdgcode,maxpt,maxy},
-    {1,"Omega-(2012)",3335,7.,0.9},
-    {1,"Omega+_bar(2012)",-3335,7.,0.9}
+    {1,"Omega-(2012)",3335,10.,0.9},
+    {1,"Omega+_bar(2012)",-3335,10.,0.9}
   };
 
   AliDecayerPythia *dec = new AliDecayerPythia;


### PR DESCRIPTION
This can be used for a new injected MC production for Omega(2012) analysis in pp 13 TeV.