### PR TITLE
Run release workflow on ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   
 jobs:
   build_release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Install Kerberos
       run: |


### PR DESCRIPTION
Hardcoding ubuntu-18.04 will fail in future, as that version is deprecated by GitHub.

I also suspect it's the cause of the recent failures of this workflow, as no runners are available with this version.