### PR TITLE
Set Geant4 sequential mode by default

### DIFF
--- a/MC/Geant4Config.C
+++ b/MC/Geant4Config.C
@@ -41,7 +41,7 @@ void Geant4Config()
 						 Form("%s", configPhysList.Data()),
 						 "specialCuts+stackPopper+stepLimiter",
 						 true,
-             false);
+						 false);
       geant4 = new TGeant4("TGeant4", 
 			   Form("The Geant4 Monte Carlo : %s, EMV-EMCAL", configPhysList.Data()), 
 			   runConfiguration);
@@ -74,7 +74,7 @@ void Geant4Config()
 						 Form("%s+monopole", configPhysList.Data()),
 						 "specialCuts+stackPopper+stepLimiter",
 						 true,
-             false);
+						 false);
       
       runConfiguration->SetParameter("monopoleMass", mass);
       runConfiguration->SetParameter("monopoleElCharge", eCh);

--- a/MC/Geant4Config.C
+++ b/MC/Geant4Config.C
@@ -40,7 +40,8 @@ void Geant4Config()
       runConfiguration = new TG4RunConfiguration("geomRoot",
 						 Form("%s", configPhysList.Data()),
 						 "specialCuts+stackPopper+stepLimiter",
-						 true);
+						 true,
+             false);
       geant4 = new TGeant4("TGeant4", 
 			   Form("The Geant4 Monte Carlo : %s, EMV-EMCAL", configPhysList.Data()), 
 			   runConfiguration);
@@ -72,7 +73,8 @@ void Geant4Config()
       runConfiguration = new TG4RunConfiguration("geomRoot",
 						 Form("%s+monopole", configPhysList.Data()),
 						 "specialCuts+stackPopper+stepLimiter",
-						 true);
+						 true,
+             false);
       
       runConfiguration->SetParameter("monopoleMass", mass);
       runConfiguration->SetParameter("monopoleElCharge", eCh);


### PR DESCRIPTION
The current Geant4 simulation is running in MT (multi-threading) mode while it should be run in sequential mode.

Ref1: https://github.com/alisw/geant4_vmc/blob/master/source/run/include/TG4RunConfiguration.h#L80
Ref2: https://github.com/alisw/AliRoot/blob/master/test/vmctest/ppbench/g4Config.C#L42