### PR TITLE
Reduce number injected signals in Hijing_Gamma002.C

### DIFF
--- a/MC/CustomGenerators/PWGGA/Hijing_Gamma002.C
+++ b/MC/CustomGenerators/PWGGA/Hijing_Gamma002.C
@@ -26,7 +26,7 @@ GeneratorCustom()
   }
   
   // PCM
-  TFormula* neutralsF  = new TFormula("neutrals",  "max(1.,470.*(x<5.)+120.*(x>7.5)*(x<12.5))");
+  TFormula* neutralsF  = new TFormula("neutrals",  "max(1.,470.*(x<5.)+72.*(x>7.5)*(x<12.5))");
   Int_t ntimes = 1;
   if ( isEmbedding )
   {


### PR DESCRIPTION
reduce number of signals for the 30-50% centrality case to aim for 30 charged tracks with pt>0.15 GeV within the TPC acceptance.